### PR TITLE
Added support for VLAN_TAGS() and DNS_ALL_FLAGS()

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
@@ -61,19 +61,23 @@ private:
   SPL::uint16 DNS_IDENTIFIER() { return ntohs(parser.dnsHeader->identifier); }
 
   inline __attribute__((always_inline))
-  SPL::uint8 DNS_OPCODE() { return parser.dnsHeader->opcodeField; }
+  SPL::uint8 DNS_OPCODE() { return parser.dnsHeader->flags.indFlags.opcodeField; }
 
   inline __attribute__((always_inline))
-  SPL::uint8 DNS_RESPONSE_CODE() { return parser.dnsHeader->responseCode; }
+  SPL::uint8 DNS_RESPONSE_CODE() { return parser.dnsHeader->flags.indFlags.responseCode; }
 
   inline __attribute__((always_inline))
-  SPL::boolean DNS_RESPONSE_FLAG() { return parser.dnsHeader->responseFlag; }
+  SPL::boolean DNS_RESPONSE_FLAG() { return parser.dnsHeader->flags.indFlags.responseFlag; }
 
   inline __attribute__((always_inline))
-  SPL::boolean DNS_AUTHORITATIVE_FLAG() { return parser.dnsHeader->authoritativeFlag; }
+  SPL::boolean DNS_AUTHORITATIVE_FLAG() { return parser.dnsHeader->flags.indFlags.authoritativeFlag; }
 
   inline __attribute__((always_inline))
-  SPL::boolean DNS_TRUNCATION_FLAG() { return parser.dnsHeader->truncatedFlag; }
+  SPL::boolean DNS_TRUNCATION_FLAG() { return parser.dnsHeader->flags.indFlags.truncatedFlag; }
+  
+  inline __attribute__((always_inline))
+  SPL::uint16 DNS_ALL_FLAGS() { return parser.dnsHeader->flags.allFlags; }
+  
 
   inline __attribute__((always_inline))
   SPL::uint16 DNS_QUESTION_COUNT() { return parser.questionCount; }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/native.function/function.xml
@@ -867,6 +867,15 @@
         </function:description>
         <function:prototype>public boolean DNS_TRUNCATION_FLAG()</function:prototype>
       </function:function>
+      
+      
+      <function:function>
+        <function:description>
+          This parser result function returns a 16 bit mask containing all flags in the DNS header of the current message. 
+          Note that no bit manipulation is being done.  Conversion from network byte order may be necessary to utilize this value later on.
+        </function:description>
+        <function:prototype>public uint16 DNS_ALL_FLAGS()</function:prototype>
+      </function:function>
 
       <function:function>
         <function:description>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -138,7 +138,8 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
 	SPL::boolean TCP_FLAGS_RESET() { return headers.tcpHeader ? headers.tcpHeader->rst : false; }
 	SPL::boolean TCP_FLAGS_SYN() { return headers.tcpHeader ? headers.tcpHeader->syn : false; }
 	SPL::boolean TCP_FLAGS_FIN() { return headers.tcpHeader ? headers.tcpHeader->fin : false; }
-	SPL::uint16 TCP_WINDOW() { return headers.tcpHeader ? ntohs(headers.tcpHeader->window) : 0; }
+	SPL::uint16 TCP_WINDOW() { return headers.tcpHeader ? ntohs(headers.tcpHeader->window) : 0; }	
+    SPL::list<uint16> VLAN_TAGS() { return (headers.convertVlanTagsToList()); }  
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource_h.cgt
@@ -232,6 +232,9 @@ public:
 
   inline __attribute__((always_inline))
   SPL::uint32 JMIRROR_SESSION_ID() { return headers.jmirrorHeader ? ntohl(headers.jmirrorHeader->jmirrorHeader.sessionIdentifier) : 0; }
+  
+  inline __attribute__((always_inline))
+  SPL::list<uint16> VLAN_TAGS() { return (headers.convertVlanTagsToList()); }  
 
   // ------------------------------------------------------------------------------------------
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketLiveSource/PacketLiveSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketLiveSource/PacketLiveSource_h.cgt
@@ -237,6 +237,9 @@ private:
 
   inline __attribute__((always_inline))
   SPL::uint32 JMIRROR_SESSION_ID() { return headers.jmirrorHeader ? ntohl(headers.jmirrorHeader->jmirrorHeader.sessionIdentifier) : 0; }
+  
+  inline __attribute__((always_inline))
+  SPL::list<uint16> VLAN_TAGS() { return (headers.convertVlanTagsToList()); }  
 
   // ------------------------------------------------------------------------------------------
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
@@ -484,7 +484,16 @@ if it has one, or zero if otherwise.
 
             </function:description>
             <function:prototype>public uint32 JMIRROR_SESSION_ID()</function:prototype>
-          </function:function>
+          </function:function>  
+            
+          <function:function>
+            <function:description>
+
+This function returns a list of 0 to N VLAN tags found in the current packet.
+
+            </function:description>
+            <function:prototype>public list&lt;uint16> VLAN_TAGS()</function:prototype>
+          </function:function>          
 
     </function:functions>
   </function:functionSet>

--- a/com.ibm.streamsx.network/impl/include/parse/DNSMessageParser.h
+++ b/com.ibm.streamsx.network/impl/include/parse/DNSMessageParser.h
@@ -42,31 +42,36 @@ class DNSMessageParser {
 
   struct DNSHeader {
     uint16_t identifier;
+    union {
+      struct {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-    uint8_t recursionDesiredFlag:1;
-    uint8_t truncatedFlag:1;
-    uint8_t authoritativeFlag:1;
-    uint8_t opcodeField:4;
-    uint8_t responseFlag:1;
-    uint8_t responseCode:4;
-    uint8_t nonauthenticatedFlag:1;
-    uint8_t authenticatedFlag:1;
-    uint8_t reserved:1;
-    uint8_t recursionAvailableFlag:1;
+        uint8_t recursionDesiredFlag:1;
+        uint8_t truncatedFlag:1;
+        uint8_t authoritativeFlag:1;
+        uint8_t opcodeField:4;
+        uint8_t responseFlag:1;
+        uint8_t responseCode:4;
+        uint8_t nonauthenticatedFlag:1;
+        uint8_t authenticatedFlag:1;
+        uint8_t reserved:1;
+        uint8_t recursionAvailableFlag:1;
 #elif __BYTE_ORDER == __BIG_ENDIAN
-    uint8_t responseFlag:1;
-    uint8_t opcodeField:4;
-    uint8_t authoritativeFlag:1;
-    uint8_t truncatedFlag:1;
-    uint8_t recursionDesiredFlag:1;
-    uint8_t recursionAvailableFlag:1;
-    uint8_t reserved:1;
-    uint8_t authenticatedFlag:1;
-    uint8_t nonauthenticatedFlag:1;
-    uint8_t responseCode:4;
+        uint8_t responseFlag:1;
+        uint8_t opcodeField:4;
+        uint8_t authoritativeFlag:1;
+        uint8_t truncatedFlag:1;
+        uint8_t recursionDesiredFlag:1;
+        uint8_t recursionAvailableFlag:1;
+        uint8_t reserved:1;
+        uint8_t authenticatedFlag:1;
+        uint8_t nonauthenticatedFlag:1;
+        uint8_t responseCode:4;
 #else
 # error "sorry, __BYTE_ORDER not setm check <bits/endian.h>"
 #endif
+      } indFlags;
+      uint16_t allFlags;
+    } flags;
     uint16_t questionCount;
     uint16_t answerCount;
     uint16_t nameserverCount;


### PR DESCRIPTION
Added two new output functions:

VLAN_TAGS().  Packet source operators can now handle parsing VLAN packets.  VLAN_TAGS will return 0 to n VLAN tags that are found in the VLAN header(s)

DNS_ALL_FLAGS() will return all flags from the DNS message in a 16 bit value.  This was requested by a customer.
