### PR TITLE
Bug fix (workaround) to DPDK

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -82,6 +82,9 @@ static void dpdkCallback(void *correlator, void *data,
 }
 
 MY_OPERATOR::MY_OPERATOR() {
+    packetCounter = 0;
+    octetCounter = 0;
+
     // Get the operator's parameters into variables.
 
     lcoreMaster = <%=$lcoreMaster%>;

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/config.h
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/config.h
@@ -46,7 +46,7 @@
 #define EM_TX_WTHRESH 8  /**< Default values of TX write-back threshold reg. */
 
 #define MAX_RX_QUEUE_PER_LCORE 4
-#define MAX_PKT_BURST  128
+#define MAX_PKT_BURST  8
 #define BURST_TX_DRAIN 220000ULL /* around 100us at 2.2 Ghz */
 
 /*


### PR DESCRIPTION
DPDK max packet burst reduced from 128 to 8 because 128 experienced buggy behaviour. To elaborate, when having 8 DPDK slave threads, only 5 of the 8 threads received packets. Furthermore, when reduced down to 64 max packet burst, only 6 of the 8 threads worked. I tested out 32, 16, 8 and 4 max packet burst, and each case worked fine with 8 threads. However, 8 max packet burst seem to give the best performance, though the differences were very minor (~1%). The change to PacketDPDKSource_cpp.cgt involves initializing two class variables to 0 in the constructor.
