### PR TITLE
Restore the thread affinity of the streams stread around DPDK init

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
@@ -131,8 +131,17 @@ MY_OPERATOR::~MY_OPERATOR() {
 void MY_OPERATOR::allPortsReady() { 
     SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> allPortsReady() ...", "DNSPacketDPDKSource");
 
+    // Retreive the pinnings before we call into the DPDK library
+    cpu_set_t cpumask;
+    CPU_ZERO(&cpumask);
+    pid_t mytid = (pid_t)syscall(SYS_gettid);
+    sched_getaffinity(mytid, sizeof(cpumask), &cpumask);
+
     int rc = streams_dpdk_init();
     if (rc != 0) THROW (SPLRuntimeOperator, "Error in streams_dpdk_init.");
+
+    // Restore the pinning of this thread after DPDK library may have messed it up
+    sched_setaffinity(mytid, sizeof(cpumask), &cpumask);
 
     tscHz = streams_source_get_tsc_hz(); 
     tscMicrosecondAdjust = (tscHz + 500000ul) / 1000000ul; 


### PR DESCRIPTION
The DPDK library pins before the pthread_start of it's master thread, polluting all future streams threads with the incorrect affinity.

This change save/restores the affinity around the dpdk init call, leaving the streams initialization thread (and all subsequent threads it creates) unpinned.  Or pinned to whatever they were beforehand.