### PR TITLE
Add more efficient ETHER_DST_ADDRESS_64() function

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_h.cgt
@@ -174,6 +174,9 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
   SPL::list<SPL::uint8> ETHER_DST_ADDRESS() { return headers.etherHeader ? SPL::list<SPL::uint8>(headers.etherHeader->h_dest, headers.etherHeader->h_dest+sizeof(headers.etherHeader->h_dest)) : SPL::list<uint8>(); }
 
   inline __attribute__((always_inline))
+  SPL::uint64 ETHER_DST_ADDRESS_64() { return headers.etherHeader ? (((uint64_t)headers.etherHeader->h_dest[0] << 40) | ((uint64_t)headers.etherHeader->h_dest[1] << 32) | ((uint64_t)headers.etherHeader->h_dest[2] << 24) | ((uint64_t)headers.etherHeader->h_dest[3] << 16) | ((uint64_t)headers.etherHeader->h_dest[4] << 8) | ((uint64_t)headers.etherHeader->h_dest[5] << 0)) : 0; }
+
+  inline __attribute__((always_inline))
   SPL::uint32 ETHER_PROTOCOL() { return headers.etherHeader ? ntohs(headers.etherHeader->h_proto) : 0; }
 
   inline __attribute__((always_inline))

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketFileSource/DNSPacketFileSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketFileSource/DNSPacketFileSource_h.cgt
@@ -169,6 +169,9 @@ public:
   SPL::list<SPL::uint8> ETHER_DST_ADDRESS() { return headers.etherHeader ? SPL::list<SPL::uint8>(headers.etherHeader->h_dest, headers.etherHeader->h_dest+sizeof(headers.etherHeader->h_dest)) : SPL::list<uint8>(); }
 
   inline __attribute__((always_inline))
+  SPL::uint64 ETHER_DST_ADDRESS_64() { return headers.etherHeader ? (((uint64_t)headers.etherHeader->h_dest[0] << 40) | ((uint64_t)headers.etherHeader->h_dest[1] << 32) | ((uint64_t)headers.etherHeader->h_dest[2] << 24) | ((uint64_t)headers.etherHeader->h_dest[3] << 16) | ((uint64_t)headers.etherHeader->h_dest[4] << 8) | ((uint64_t)headers.etherHeader->h_dest[5] << 0)) : 0; }
+
+  inline __attribute__((always_inline))
   SPL::uint32 ETHER_PROTOCOL() { return headers.etherHeader ? ntohs(headers.etherHeader->h_proto) : 0; }
 
   inline __attribute__((always_inline))

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketLiveSource/DNSPacketLiveSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketLiveSource/DNSPacketLiveSource_h.cgt
@@ -164,6 +164,9 @@ private:
   SPL::list<SPL::uint8> ETHER_DST_ADDRESS() { return headers.etherHeader ? SPL::list<SPL::uint8>(headers.etherHeader->h_dest, headers.etherHeader->h_dest+sizeof(headers.etherHeader->h_dest)) : SPL::list<uint8>(); }
 
   inline __attribute__((always_inline))
+  SPL::uint64 ETHER_DST_ADDRESS_64() { return headers.etherHeader ? (((uint64_t)headers.etherHeader->h_dest[0] << 40) | ((uint64_t)headers.etherHeader->h_dest[1] << 32) | ((uint64_t)headers.etherHeader->h_dest[2] << 24) | ((uint64_t)headers.etherHeader->h_dest[3] << 16) | ((uint64_t)headers.etherHeader->h_dest[4] << 8) | ((uint64_t)headers.etherHeader->h_dest[5] << 0)) : 0; }
+
+  inline __attribute__((always_inline))
   SPL::uint32 ETHER_PROTOCOL() { return headers.etherHeader ? ntohs(headers.etherHeader->h_proto) : 0; }
 
   inline __attribute__((always_inline))

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/native.function/function.xml
@@ -313,6 +313,14 @@ This function returns the ethernet destination address of the current packet.
           <function:function>
             <function:description>
 
+This function returns the ethernet destination address of the current packet in the 48 low-order bits of a uint64.
+
+            </function:description>
+            <function:prototype>public uint64 ETHER_DST_ADDRESS_64()</function:prototype>
+          </function:function>
+          <function:function>
+            <function:description>
+
 This function returns the ethernet protocol (that is, the EtherType) of the
 current packet, for example, '2048' for IP version 4, or '34,525' for IP version 6.
 


### PR DESCRIPTION
ETHER_DST_ADDRESS() returns a bounded list of uint8_t values for the bytes of the MAC address.  Profiles show this can become a bottleneck, by generating a lot of blist temporaries that dynamically allocate the bytes in the list.  This is fine, up to a point, where the thread local allocation cache for these extremely tiny allocations gets filled up, causing tcmalloc to try to juggle the process-wide cache.  With lots of threads all doing this simultaneously, it becomes quite a point of contention.

We can't just replace ETHER_DST_ADDRESS() with one returning a uint64_t directly, for backwards-compatibility reasons, so I added a new variant that can be used when we need the path to be very efficient.

The shift, mask, and or sequence looks a bit ugly in the inline, but pretty much all compilers on all 64-bit architectures should be able to optimize this fairly well, into just a couple of instructions.
