### PR TITLE
Restore affinity around DPDK init call in PacketDPDKSource (non-DNS)

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
@@ -135,13 +135,21 @@ void MY_OPERATOR::allPortsReady() {
     cpu_set_t cpumask;
     CPU_ZERO(&cpumask);
     pid_t mytid = (pid_t)syscall(SYS_gettid);
-    sched_getaffinity(mytid, sizeof(cpumask), &cpumask);
+    bool restore_affinity = true;
+    if(sched_getaffinity(mytid, sizeof(cpumask), &cpumask) != 0) {
+        SPLAPPTRC(L_ERROR, "sched_getaffinity() returned errno = " << errno, "DNSPacketDPDKSource");
+        restore_affinity = false;
+    }
 
     int rc = streams_dpdk_init();
     if (rc != 0) THROW (SPLRuntimeOperator, "Error in streams_dpdk_init.");
 
     // Restore the pinning of this thread after DPDK library may have messed it up
-    sched_setaffinity(mytid, sizeof(cpumask), &cpumask);
+    if(restore_affinity) {
+        if(sched_setaffinity(mytid, sizeof(cpumask), &cpumask) != 0) {
+            SPLAPPTRC(L_ERROR, "sched_setaffinity() returned errno = " << errno, "DNSPacketDPDKSource");
+        }
+    }
 
     tscHz = streams_source_get_tsc_hz(); 
     tscMicrosecondAdjust = (tscHz + 500000ul) / 1000000ul; 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -143,9 +143,26 @@ void MY_OPERATOR::allPortsReady() {
   std::string buffersizes(temp.str());
   if (buffersizes.size()) buffersizes.erase(buffersizes.size()-1, 1);
 
+    // Retreive the pinnings before we call into the DPDK library
+    cpu_set_t cpumask;
+    CPU_ZERO(&cpumask);
+    pid_t mytid = (pid_t)syscall(SYS_gettid);
+    bool restore_affinity = true;
+    if(sched_getaffinity(mytid, sizeof(cpumask), &cpumask) != 0) {
+        SPLAPPTRC(L_ERROR, "sched_getaffinity() returned errno = " << errno, "PacketDPDKSource");
+        restore_affinity = false;
+    }
+
     // initialize DPDK
     int rc = streams_dpdk_init(buffersizes.c_str());
     if (rc != 0) { THROW (SPLRuntimeOperator, "Error in streams_dpdk_init."); }
+
+    // Restore the pinning of this thread after DPDK library may have messed it up
+    if(restore_affinity) {
+        if(sched_setaffinity(mytid, sizeof(cpumask), &cpumask) != 0) {
+            SPLAPPTRC(L_ERROR, "sched_setaffinity() returned errno = " << errno, "PacketDPDKSource");
+        }
+    }
 
     // get system clock rate
     tscHz = streams_source_get_tsc_hz(); 


### PR DESCRIPTION
Also, add extra error checking around the sched_getaffinity()/setaffinity() calls, just to let us see if something goes wrong (and to prevent "restoring" an affinity that we never successfully acquired.