### PR TITLE
Fix metricsUpdate handling in the packetProcess() method

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
@@ -101,6 +101,13 @@ MY_OPERATOR::MY_OPERATOR() {
   byteCounter = byteCounterNow = byteCounterThen = 0;
   now = then = 0;
   metricsUpdate = false;
+#ifdef __ATOMIC_RELAXED
+  __atomic_store_n(&realMetricsUpdate, false, __ATOMIC_RELEASE);
+#else
+  #pragma message "Using old sync builtins, with GCC " __VERSION__
+  // __sync_synchronize();  // Unnecessary here, in startup, as we're not yet protecting anything from any other threads.  Leaving as reminder that this variable is an atomic.
+  realMetricsUpdate = false;
+#endif
 
   // clear the output tuples
   <% for (my $i=0; $i<$model->getNumberOfOutputPorts(); $i++) { %> ;
@@ -245,6 +252,29 @@ void MY_OPERATOR::packetProcess(uint8_t *packet, uint32_t length, uint64_t tscTi
   packetCounter++;
   byteCounter += packetLen;
 
+  // Determine if the metrics were updated prior to this packet.
+  // Update the "local" version of the metrics updated flag, so that all output filters/assignments reference a stable copy.
+  /// @todo Under extremely low packet rates, or very short metrics update intervals, it's possible that the previous
+  // metrics copy hasn't yet been consumed when a new one comes in, causing either a total loss of a metrics update,
+  // or, if it lines up just right with an incoming packet, a metrics update with "odd" or part old/part new values.
+  // This should be very uncommon, and not catastrophic, so we are not attempted to protect against this just yet.
+  // This could be addressed at some future time.
+
+#ifdef __ATOMIC_RELAXED
+  bool expected = true;
+  if(__atomic_compare_exchange_n(&realMetricsUpdate, &expected, false, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+      metricsUpdate = true;
+  } else {
+      metricsUpdate = false;
+  }
+#else
+  if(__sync_bool_compare_and_swap(&realMetricsUpdate, true, false)) {
+      metricsUpdate = true;
+  } else {
+      metricsUpdate = false;
+  }
+#endif
+
   // fill in and submit output tuples to output ports, as selected by output filters, if specified
   <% for (my $i=0; $i<$model->getNumberOfOutputPorts(); $i++) { %> ;
     <% if (scalar($outputFilterList[$i])) { print "if ($outputFilterList[$i])"; } %> 
@@ -255,7 +285,9 @@ void MY_OPERATOR::packetProcess(uint8_t *packet, uint32_t length, uint64_t tscTi
     }
     <% } %> ;
 
-  // reset the 'metrics updated' flag, in case one of the output filters or assignments references it
+  // reset the "local" version of the 'metrics updated' flag, in case one of the output filters or assignments references it
+  // The "real" version of the flag, as updated by the metricsThread() is unaffected, so we don't lose metrics updates under high-packet-rate
+  // conditions.
   metricsUpdate = false;
 }
 
@@ -324,7 +356,13 @@ void MY_OPERATOR::metricsThread() {
       totalBytesProcessed->setValue(byteCounter);
       
       // updated metrics will be available to the next output tuple emitted
-      metricsUpdate = true;
+#ifdef __ATOMIC_RELAXED
+      __atomic_store_n(&realMetricsUpdate, true, __ATOMIC_RELEASE);
+#else
+      __sync_synchronize();
+      realMetricsUpdate = true;
+#endif
+
     }
 
     SPLAPPTRC(L_DEBUG, "leaving <%=$myOperatorKind%> metricsThread()", "DNSPacketDPDKSource");

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_h.cgt
@@ -98,6 +98,7 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
   struct port_stats statsNow, statsThen; 
   double now, then;  
   bool metricsUpdate;
+  bool realMetricsUpdate;
 
   // ----------- network header parser ----------
   


### PR DESCRIPTION
Fix for secondary issue found while debugging another problem.  Due to multiple threads updating this flag concurrently, sometimes metrics updates were being lost.  This commit fixes that, by making sure all accesses of the shared flag are atomic.  On RHEL6 builds, the __atomic_* builtins aren't available, so I have to use the worse-performing, less flexible __sync_* builtins.