### PR TITLE
Performance Improvements for IPFilter and TextFilter

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/IPFilter/IPFilter.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/IPFilter/IPFilter.xml
@@ -30,6 +30,15 @@ The supported data types for this attribute are `uint32` and `list&lt;uint32>`.<
         <expressionMode>Expression</expressionMode>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>inputIPAttr2</name>
+        <description>Specifies an additional input attribute containing an additional IPv4 address (or IPv4 addresses) that the filter will be applied against.
+The supported data types for this attribute are `uint32` and `list&lt;uint32>`.</description>
+        <optional>true</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Expression</expressionMode>
+        <cardinality>1</cardinality>
+      </parameter>
    </parameters>
     <inputPorts>
       <inputPortSet>
@@ -58,9 +67,9 @@ This control port can be used to dynamically update the list of addresses being 
     <outputPorts>
       <outputPortSet>
         <description>Submits a tuple for each input tuple received on input port 0 if one or more of the attributes defined in the inputIPAttr paramater match an IPv4 address that has been input on the control port.</description>
-        <expressionMode>Expression</expressionMode>
+        <expressionMode>Nonexistent</expressionMode>
         <autoAssignment>true</autoAssignment>
-        <completeAssignment>false</completeAssignment>
+        <completeAssignment>true</completeAssignment>
         <rewriteAllowed>true</rewriteAllowed>
         <windowPunctuationOutputMode>Preserving</windowPunctuationOutputMode>
         <windowPunctuationInputPort>0</windowPunctuationInputPort>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/IPFilter/IPFilter_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/IPFilter/IPFilter_cpp.cgt
@@ -42,7 +42,7 @@ if(defined $inputPort1) {
 
 # get C++ expressions for getting the values of this operator's parameters
 my $inputIPAttrParamCppValue = $model->getParameterByName("inputIPAttr")->getValueAt(0)->getCppExpression();
-
+my $inputIPAttrParam2 = $model->getParameterByName("inputIPAttr2");
 %>
 
 <%SPL::CodeGen::implementationPrologue($model);%>
@@ -87,21 +87,26 @@ void MY_OPERATOR::process(Tuple & tuple, uint32_t port) {
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
     SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> process() non-mutating.", IP_FILTER);
 
-	if(port == 0) {
-    	const IPort0Type& iport$0 = tuple;
+    if(port == 0) {
+        const IPort0Type& iport$0 = tuple;
         bool ipAddrMatch = false;
-		
+
         SPLAPPTRC(L_TRACE, "Process non-mutating, port 0.", IP_FILTER);
-		{
-			AutoPortMutex amR(mutex_[ip4ListRSel_], *this);
-			ipAddrMatch = lookupIPv4(<%=$inputIPAttrParamCppValue%>);
-			
+
+        {
+            AutoPortMutex amR(mutex_[ip4ListRSel_], *this);
+            ipAddrMatch = lookupIPv4(<%=$inputIPAttrParamCppValue%>);
+<% if(defined $inputIPAttrParam2) { %>
+            ipAddrMatch = ipAddrMatch || lookupIPv4(<%=$inputIPAttrParam2->getValueAt(0)->getCppExpression()%>);
+<% } %>
         }
-        if(ipAddrMatch) {	
-            <% CodeGenX::copyOutputAttributesFromInputAttributes("outTuple", $model->getOutputPortAt(0), $model->getInputPortAt(0)); %> ;
-            <% CodeGenX::assignOutputAttributeValues("outTuple", $model->getOutputPortAt(0)); %> ;
-            SPLAPPTRC(L_TRACE, "submitting outTuple=" << outTuple, IP_FILTER);
-            submit(outTuple, 0);
+
+        if(ipAddrMatch) {
+//            <% # CodeGenX::copyOutputAttributesFromInputAttributes("outTuple", $model->getOutputPortAt(0), $model->getInputPortAt(0)); %> ;
+//            <% # CodeGenX::assignOutputAttributeValues("outTuple", $model->getOutputPortAt(0)); %> ;
+//            SPLAPPTRC(L_TRACE, "submitting outTuple=" << outTuple, IP_FILTER);
+//            submit(outTuple, 0);
+            submit(iport$0, 0);
         }
     }
     <% if(defined $inputPort1) {%>
@@ -123,7 +128,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
             }
             return;
         }
-	<%}%>
+    <%}%>
 }
 
 // Punctuation processing

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/IPFilter/IPFilter_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/IPFilter/IPFilter_cpp.cgt
@@ -91,7 +91,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
         const IPort0Type& iport$0 = tuple;
         bool ipAddrMatch = false;
 
-        SPLAPPTRC(L_TRACE, "Process non-mutating, port 0.", IP_FILTER);
+        SPLAPPTRC(L_TRACE, "Process() non-mutating, port 0.", IP_FILTER);
 
         {
             AutoPortMutex amR(mutex_[ip4ListRSel_], *this);
@@ -114,11 +114,12 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
             const IPort1Type& iport$1 = tuple;
             rstring ipv4Addr = <%=$inputPort1CppName%>.get_<%=$ipv4AddrFilterAttribute%>();
 
-            SPLAPPTRC(L_TRACE, "Process non-mutating, port 1.  ipv4FilterAddr = " << ipv4Addr, IP_FILTER);
+            SPLAPPTRC(L_WARN, "Process() non-mutating, port 1.  ipv4FilterAddr = " << ipv4Addr, IP_FILTER);
+
+            SPL::list<SPL::uint32> addrList = getAllAddressesInNetworkInt(ipv4Addr);
+            SPLAPPTRC(L_WARN, "Process() non-mutating, port 1.  Adding count = " << addrList.size(), IP_FILTER);
 
             AutoPortMutex amW(mutex_[ip4ListWSel_], *this);
-            SPL::list<SPL::uint32> addrList = getAllAddressesInNetworkInt(ipv4Addr);
-            SPLAPPTRC(L_TRACE, "Process non-mutating, port 1 in lock.  size = " << addrList.size(), IP_FILTER);
             SPL::list<SPL::uint32>::const_iterator it;
             for(it = addrList.begin(); it != addrList.end(); ++it) {
                 ip4List_[ip4ListWSel_]->insert(*it);
@@ -137,15 +138,15 @@ void MY_OPERATOR::process(Punctuation const & punct, uint32_t port) {
 
 	if(port == 1) {
         if(punct==Punctuation::WindowMarker) {
-            SPLAPPTRC(L_TRACE, "<%=$myOperatorKind%> process() punctuation: window.", IP_FILTER);
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() punctuation: window.", IP_FILTER);
 
             // Take both the R & W mutexes so we can close out the current filter list 
             // and swap lists atomically. This is the very uncommon case
             // so the locking overhead is not important.
-            AutoPortMutex amR(mutex_[ip4ListRSel_], *this);
             AutoPortMutex amW(mutex_[ip4ListWSel_], *this);
+            AutoPortMutex amR(mutex_[ip4ListRSel_], *this);
 
-            SPLAPPTRC(L_TRACE, "<%=$myOperatorKind%> process() sending WindowMarker out port 0.", IP_FILTER);
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() sending WindowMarker out port 0.", IP_FILTER);
             submit(Punctuation::WindowMarker, 0);
 
             uint32_t tmpList = ip4ListWSel_;
@@ -154,7 +155,7 @@ void MY_OPERATOR::process(Punctuation const & punct, uint32_t port) {
 
             ip4List_[ip4ListWSel_]->clear();
         } else if(punct==Punctuation::FinalMarker) {
-            SPLAPPTRC(L_TRACE, "<%=$myOperatorKind%> process() punctuation: final.", IP_FILTER);
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() punctuation: final.", IP_FILTER);
             // ...;
         }
     }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/TextFilter/TextFilter.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/TextFilter/TextFilter.xml
@@ -58,9 +58,9 @@ This control port can be used to dynamically update the list of addresses being 
     <outputPorts>
       <outputPortSet>
         <description>Submits a tuple for each input tuple received on input port 0 if one or more of the attributes defined in the inputIPAttr paramater match an IPv4 address that has been input on the control port.</description>
-        <expressionMode>Expression</expressionMode>
+        <expressionMode>Nonexistent</expressionMode>
         <autoAssignment>true</autoAssignment>
-        <completeAssignment>false</completeAssignment>
+        <completeAssignment>true</completeAssignment>
         <rewriteAllowed>true</rewriteAllowed>
         <windowPunctuationOutputMode>Preserving</windowPunctuationOutputMode>
         <windowPunctuationInputPort>0</windowPunctuationInputPort>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/TextFilter/TextFilter_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/TextFilter/TextFilter_cpp.cgt
@@ -55,10 +55,26 @@ MY_OPERATOR::MY_OPERATOR() {
 
     textListValid_[textListRSel_] = false;
     textListValid_[textListWSel_] = false;
+
+    memset(&compiledRe_[textListRSel_], 0, sizeof(regex_t));
+    memset(&compiledRe_[textListWSel_], 0, sizeof(regex_t));
+
+    regexCompiled_[textListRSel_] = false;
+    regexCompiled_[textListWSel_] = false;
 }
 
 // Destructor
 MY_OPERATOR::~MY_OPERATOR() {
+    // Free up any compiled REs
+    if(regexCompiled_[textListRSel_]) {
+        regfree(&compiledRe_[textListRSel_]);
+        regexCompiled_[textListRSel_] = false;
+    }
+
+    if(regexCompiled_[textListWSel_]) {
+        regfree(&compiledRe_[textListWSel_]);
+        regexCompiled_[textListWSel_] = false;
+    }
 }
 
 // Notify port readiness
@@ -110,7 +126,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
         else if(port == 1) {
             const IPort1Type& iport$1 = tuple;
 
-            SPLAPPTRC(L_TRACE, "Process non-mutating, port 1.", TEXT_FILTER);
+            SPLAPPTRC(L_WARN, "Process non-mutating, port 1.", TEXT_FILTER);
             rstring text = firstInGroup ? 
                 SPL::Functions::String::concat("(", <%=$inputPort1CppName%>.get_<%=$textFilterAttribute%>()) :
                 SPL::Functions::String::concat("|", <%=$inputPort1CppName%>.get_<%=$textFilterAttribute%>());
@@ -118,8 +134,9 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
             AutoPortMutex amW(mutex_[textListWSel_], *this);
             firstInGroup = false;
             textListValid_[textListWSel_] = true;
+            regexCompiled_[textListWSel_] = false;
             textList_[textListWSel_] = SPL::Functions::String::concat(textList_[textListWSel_], text);
-            SPLAPPTRC(L_TRACE, "Process non-mutating, port 1.  textList_ = " << textList_[textListWSel_], TEXT_FILTER);
+            SPLAPPTRC(L_WARN, "Process non-mutating, port 1.  textList_ = " << textList_[textListWSel_], TEXT_FILTER);
             return;
         }
     <%}%>
@@ -131,29 +148,67 @@ void MY_OPERATOR::process(Punctuation const & punct, uint32_t port) {
 
 	if(port == 1) {
         if(punct==Punctuation::WindowMarker) {
-            SPLAPPTRC(L_TRACE, "<%=$myOperatorKind%> process() punctuation: window.", TEXT_FILTER);
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() punctuation: window.", TEXT_FILTER);
+
             // Take both the R & W mutexes so we can close out the current filter list
             // and swap lists atomically. This is the very uncommon case
             // so the locking overhead is not important.
-            AutoPortMutex amR(mutex_[textListRSel_], *this);
+            // However, we first grab just the writer's mutex while compiling,
+            // to avoid slowing down tuple processing.
             AutoPortMutex amW(mutex_[textListWSel_], *this);
 
-            if(textListValid_[textListWSel_]) {
-                textList_[textListWSel_] = SPL::Functions::String::concat(textList_[textListWSel_], ")");
+            // Free up this regex's pattern space, if it was previously compiled
+            if(regexCompiled_[textListWSel_]) {
+                regfree(&compiledRe_[textListWSel_]);
+                regexCompiled_[textListWSel_] = false;
+                memset(&compiledRe_[textListWSel_], 0, sizeof(regex_t));
             }
 
-            SPLAPPTRC(L_TRACE, "<%=$myOperatorKind%> process() sending WindowMarker out port 0. textList_ = " << textList_[textListWSel_], TEXT_FILTER);
+            // Only need to actually compile a new regex if there is actually one for us to use.
+            if(textListValid_[textListWSel_]) {
+                textList_[textListWSel_] = SPL::Functions::String::concat(textList_[textListWSel_], ")");
+
+                // Actually compile the new regex
+                int rc = regcomp(&compiledRe_[textListWSel_], textList_[textListWSel_].c_str(), REG_EXTENDED | REG_NOSUB);
+                if(rc) {
+                    // RE compilation error!  Must be a bad regex.
+                    char errbuf[1024];
+                    memset(errbuf, 0, 1024);
+                    regerror(rc, &compiledRe_[textListWSel_], errbuf, 1024);
+                    SPLAPPTRC(L_ERROR, "<%=$myOperatorKind%> Regular Expression /" << textList_[textListWSel_] << "/ failed to compile properly.  Until fixed, this group won't match anything.  regerror reports: " << errbuf, TEXT_FILTER);
+                    regfree(&compiledRe_[textListWSel_]);
+                    regexCompiled_[textListWSel_] = false;
+                    memset(&compiledRe_[textListWSel_], 0, sizeof(regex_t));
+                } else {
+                    // RE compiled fine.  We can proceed.
+                    regexCompiled_[textListWSel_] = true;
+                    SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() Regex compiled and ready. textList_ = " << textList_[textListWSel_], TEXT_FILTER);
+                }
+            } else {
+                // No regex.  That's fine, just leave textListValid and regexCompiled false, so lookupText() short circuits, later.
+                SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() No Regex to compile for this group.", TEXT_FILTER);
+            }
+
+            // Ok, all ready to do the swap, so grab the reader mutex as well now.
+            AutoPortMutex amR(mutex_[textListRSel_], *this);
+
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() sending Window punctuation out port 0", TEXT_FILTER);
             submit(Punctuation::WindowMarker, 0);
 
             uint32_t tmpList = textListWSel_;
             textListWSel_ = textListRSel_;
             textListRSel_ = tmpList;
 
+            // Keep in mind that at this point textListWSel_ refers to what _used_ to be textListRSel_.
+            // That is, the previous regex that was actively being used for matches until just a moment ago.
+            // We need to clear the regex string out here to allow for its re-use in the future, when new regex terms come in.
+            // However, we will avoid freeing the actual compiled regex until we compile it next time, to avoid
+            // keeping the (new) read lock longer than we need to.
             textListValid_[textListWSel_] = false;
             firstInGroup = true;
             textList_[textListWSel_] = "";
         } else if(punct==Punctuation::FinalMarker) {
-            SPLAPPTRC(L_TRACE, "<%=$myOperatorKind%> process() punctuation: final.", TEXT_FILTER);
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() punctuation: final.", TEXT_FILTER);
         }
     }
 }
@@ -171,19 +226,15 @@ bool inline MY_OPERATOR::lookupText(const SPL::list<rstring> &textList) {
 }
 
 bool inline MY_OPERATOR::lookupText(const rstring &text) {
-    if(!textListValid_[textListRSel_]) {
+    if(!textListValid_[textListRSel_] || !regexCompiled_[textListRSel_]) {
         return false;
     }
 
-    SPL::list<rstring> matches = SPL::Functions::String::regexMatch(text, textList_[textListRSel_]);
+    int rc = regexec(&compiledRe_[textListRSel_], text.c_str(), 0, NULL, 0);
 
-    SPLAPPTRC(L_TRACE, "lookupText.  matches = " << matches << ", size = " << matches.size() << ", text = " << text << ", textList = " << textList_[textListRSel_], TEXT_FILTER);
+    SPLAPPTRC(L_TRACE, "lookupText.  regexec rc = " << rc << ", text = " << text << ", textList = " << textList_[textListRSel_], TEXT_FILTER);
 
-    if(matches.size()) {
-        return true;
-    } else {
-        return false;
-    }
+    return (rc == 0) ? true : false;
 }
 
 <%SPL::CodeGen::implementationEpilogue($model);%>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/TextFilter/TextFilter_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/TextFilter/TextFilter_cpp.cgt
@@ -87,21 +87,23 @@ void MY_OPERATOR::process(Tuple & tuple, uint32_t port) {
 void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
     SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> process() non-mutating.", TEXT_FILTER);
 
-	if(port == 0) {
-    	const IPort0Type& iport$0 = tuple;
+    if(port == 0) {
+        const IPort0Type& iport$0 = tuple;
         bool textMatch = false;
-		
+
         SPLAPPTRC(L_TRACE, "Process non-mutating, port 0.", TEXT_FILTER);
-		{
-			AutoPortMutex amR(mutex_[textListRSel_], *this);
-			textMatch = lookupText(<%=$inputTextAttrParamCppValue%>);
-			
+
+        {
+            AutoPortMutex amR(mutex_[textListRSel_], *this);
+            textMatch = lookupText(<%=$inputTextAttrParamCppValue%>);
         }
-        if(textMatch) {	
-            <% CodeGenX::copyOutputAttributesFromInputAttributes("outTuple", $model->getOutputPortAt(0), $model->getInputPortAt(0)); %> ;
-            <% CodeGenX::assignOutputAttributeValues("outTuple", $model->getOutputPortAt(0)); %> ;
-            SPLAPPTRC(L_TRACE, "submitting outTuple=" << outTuple, TEXT_FILTER);
-            submit(outTuple, 0);
+
+        if(textMatch) {
+//            <% # CodeGenX::copyOutputAttributesFromInputAttributes("outTuple", $model->getOutputPortAt(0), $model->getInputPortAt(0)); %> ;
+//            <% # CodeGenX::assignOutputAttributeValues("outTuple", $model->getOutputPortAt(0)); %> ;
+//            SPLAPPTRC(L_TRACE, "submitting outTuple=" << outTuple, TEXT_FILTER);
+//            submit(outTuple, 0);
+            submit(iport$0, 0);
         }
     }
     <% if(defined $inputPort1) {%>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/TextFilter/TextFilter_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/TextFilter/TextFilter_h.cgt
@@ -4,6 +4,8 @@
 %>
 
 /* Additional includes go here */
+#include <sys/types.h>
+#include <regex.h>
 
 <%SPL::CodeGen::headerPrologue($model);%>
 
@@ -39,6 +41,8 @@ private:
   SPL::Mutex mutex_[2] ;
   TextList textList_[2];
   bool       textListValid_[2];
+  regex_t    compiledRe_[2];
+  bool       regexCompiled_[2];
 
   int32_t textListRSel_;
   int32_t textListWSel_;


### PR DESCRIPTION
Simple change to IPFilter to allow a common use case, checking src and dest IP addresses against the filter, to not require an SPL::List construction, which profiles has shown in this case is exorbitantly expensive.

Larger change on the TextFilter side to avoid the SPL wrapper around the standard POSIX regex library calls, which introduce a bunch of locking and caching of regex compiles.  In this case, we have our own locks held while updating the "next" regex, which doesn't impact the use of the "previous" regex.  We only have a single regex to compile for this operator, and it can be compiled long before first use.  The changes, while not minimal, are very straightforward and yield a huge gain in RE throughput, even without changing the regex engine in use.

Additional minor changes in both operators:
 - Change the lock sequencing at the switch-over points to minimize the lengths of each critical section
 - Improve debug tracing
 - Avoid needlessly copying tuples when this is simply a Filter operator: input type is equal to output type, and no tuple members are modified

