### PR TITLE
Add domain extraction

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/ExtractDomain/ExtractDomain.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/ExtractDomain/ExtractDomain.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  
+Copyright (C)2017, International Business Machines Corporation and  
+others. All Rights Reserved. 
+-->
+<operatorModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ibm.com/xmlns/prod/streams/spl/operator" xmlns:cmn="http://www.ibm.com/xmlns/prod/streams/spl/common" xsi:schemaLocation="http://www.ibm.com/xmlns/prod/streams/spl/operator operatorModel.xsd">
+  <cppOperatorModel>
+    <context>
+      <description>This operator extracts the domain+tld portion of a fqdn in a tuple, and sets a pre-existing field in the tuple to that value.</description>
+      <libraryDependencies>
+        <library>
+          <cmn:description>   </cmn:description>
+          <cmn:managedLibrary>
+            <cmn:includePath>../../impl/include</cmn:includePath>
+          </cmn:managedLibrary>
+        </library>
+      </libraryDependencies>
+      <providesSingleThreadedContext>Never</providesSingleThreadedContext>
+      <allowCustomLogic>false</allowCustomLogic>
+    </context>
+    <parameters>
+      <description></description>
+      <allowAny>false</allowAny>
+      <parameter>
+        <name>inputFQDNAttr</name>
+        <description>Specifies the input attribute containing the FQDN that the extraction will be performed on.
+The supported data type for this attribute is `rstring`.</description>
+        <optional>false</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Expression</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>outputDomainAttr</name>
+        <description>Specifies the output attribute to write the extracted domain+TLD data to.  Existing data will be overwritten.
+If the FQDN is malformed, or doesn't match a known TLD, this field will be empty.
+The supported data type for this attribute is `rstring`.</description>
+        <optional>false</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Attribute</expressionMode>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
+        <name>blankOnInvalidTLD</name>
+        <description>
+By default, if the FQDN doesn't match any TLD, the outputDomainAttr field is filled in with the entire incoming FQDN.
+If blankOnInvalidTLD is set, when no valid TLD is found, the outputDomainAttr field is left blank.
+        </description>
+        <optional>true</optional>
+        <rewriteAllowed>false</rewriteAllowed>
+        <expressionMode>Constant</expressionMode>
+        <type>boolean</type>
+        <cardinality>1</cardinality>
+        <portScope><port>0</port></portScope>
+      </parameter>
+   </parameters>
+    <inputPorts>
+      <inputPortSet>
+        <description>Ingests tuples containing FQDNs in the `inputFQDNAttr` field, extracts the domain, and sets it into the `outputDomainAttr` field before sending the tuple on.</description>
+        <windowingDescription></windowingDescription>
+        <tupleMutationAllowed>true</tupleMutationAllowed>
+        <windowingMode>NonWindowed</windowingMode>
+        <windowPunctuationInputMode>Oblivious</windowPunctuationInputMode>
+        <controlPort>false</controlPort>
+        <cardinality>1</cardinality>
+        <optional>false</optional>
+      </inputPortSet>
+      <inputPortSet>
+        <description>Control port that takes in tuples containing TLDs for use in later extractions.
+This control port can be used to dynamically update the list of TLDs used for extraction. Each time a tuple is received containing a TLD it is saved in a temporary TLD list that is applied after a window punctuation is received on this port.  This input port expects a tuple containing a single attribute of type `rstring` which is a TLD name.</description>
+        <windowingDescription></windowingDescription>
+        <tupleMutationAllowed>false</tupleMutationAllowed>
+        <windowingMode>NonWindowed</windowingMode>
+        <windowPunctuationInputMode>Oblivious</windowPunctuationInputMode>
+        <controlPort>true</controlPort>
+        <cardinality>1</cardinality>
+        <optional>false</optional>
+      </inputPortSet>
+    </inputPorts>
+    <outputPorts>
+      <outputPortSet>
+        <description>Submits each input tuple after updating the field indicated by the `outputDomainAttr` parameter with the domain+TLD extracted from the FQDN field (indicated by the `inputFQDNAttr` parameter).</description>
+        <expressionMode>Nonexistent</expressionMode>
+        <autoAssignment>true</autoAssignment>
+        <completeAssignment>true</completeAssignment>
+        <rewriteAllowed>true</rewriteAllowed>
+        <windowPunctuationOutputMode>Preserving</windowPunctuationOutputMode>
+        <windowPunctuationInputPort>0</windowPunctuationInputPort>
+        <tupleMutationAllowed>true</tupleMutationAllowed>
+        <cardinality>1</cardinality>
+        <optional>false</optional>
+      </outputPortSet>
+    </outputPorts>
+  </cppOperatorModel>
+</operatorModel>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/ExtractDomain/ExtractDomain_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/ExtractDomain/ExtractDomain_cpp.cgt
@@ -1,0 +1,262 @@
+<%
+## Copyright (C) 2017  International Business Machines Corporation
+## All Rights Reserved
+%>
+
+/*
+ */
+
+#include <string>
+#include <arpa/inet.h>
+#include "NetworkResources.h"
+
+#define EXTRACT_DOMAIN "EXTRACT_DOMAIN"
+
+using namespace SPL;
+using namespace std;
+
+<%
+unshift @INC, dirname($model->getContext()->getOperatorDirectory()) . "/../impl/bin";
+require CodeGenX;
+
+# These fragments of Perl code get strings from the operator's declaration
+# in the SPL source code for use in generating C/C++ code for the operator's
+# implementation below
+
+# get the name of this operator's template
+my $myOperatorKind = $model->getContext()->getKind();
+
+# get Perl objects for input and output ports
+my $inputPort0 = $model->getInputPortAt(0);
+my $inTupleType0 = $inputPort0->getCppTupleType();
+my $inputPort1 = $model->getInputPortAt(1);
+
+my $outputPort = $model->getOutputPortAt(0);
+my $outTupleType = $outputPort->getCppTupleType();
+
+# Verify the main input port and output port are of the same type.
+# They need to be!
+SPL::CodeGen::exitln(SPL::Msg::STDTK_OUTPUT_SCHEMA_NOT_MATCHING_INPUT(0, 0),
+                         $inputPort0->getSourceLocation()) if ($inTupleType0 ne $outTupleType);
+
+my $inputPort1CppName = $inputPort1->getCppTupleName();
+my $tldAttribute = $inputPort1->getAttributeAt(0)->getName();
+
+# get C++ expressions for getting the values of this operator's parameters
+my $inputFQDNAttrParamCppValue = $model->getParameterByName("inputFQDNAttr")->getValueAt(0)->getCppExpression();
+
+my $outputDomainAttr = $model->getParameterByName("outputDomainAttr")->getValueAt(0)->getSPLExpression();
+# remove the stream name from the attribute
+$outputDomainAttr =~ s/^.*\.//;
+
+my $blankOnInvalid = $model->getParameterByName("blankOnInvalidTLD");
+$blankOnInvalid = $blankOnInvalid ? $blankOnInvalid->getValueAt(0)->getSPLExpression() eq "true" : undef;
+
+%>
+
+<%SPL::CodeGen::implementationPrologue($model);%>
+
+// Constructor
+MY_OPERATOR::MY_OPERATOR() {
+    tldsRSel_ = 0;
+    tldsWSel_ = 1;
+    firstListLoaded_ = false;
+
+    tlds_[0] = new TLDSet();
+    tlds_[1] = new TLDSet();
+}
+
+// Destructor
+MY_OPERATOR::~MY_OPERATOR() {
+    delete tlds_[0];
+    delete tlds_[1];
+}
+
+// Notify port readiness
+void MY_OPERATOR::allPortsReady() {
+    // Notifies that all ports are ready. No tuples should be submitted before
+    // this. Source operators can use this method to spawn threads.
+
+    /*
+      createThreads(1); // Create source thread
+    */
+}
+ 
+// Notify pending shutdown
+void MY_OPERATOR::prepareToShutdown() {
+    // This is an asynchronous call
+}
+
+// Tuple processing for mutating ports
+void MY_OPERATOR::process(Tuple & tuple, uint32_t port) {
+    SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> process() mutating.", EXTRACT_DOMAIN);
+
+    if(port == 0) {
+        IPort0Type& iport$0 = (IPort0Type &)tuple;
+
+        std::string fqdn = <%=$inputFQDNAttrParamCppValue%>;
+        SPLAPPTRC(L_TRACE, "Process mutating, port 0: " << fqdn, EXTRACT_DOMAIN);
+
+        // Switch it to lower case, since that's how the TLDs will be
+        for(size_t i = 0; i < fqdn.length(); ++i) {
+            fqdn[i] = ::tolower(fqdn[i]);
+        }
+
+
+        // search the input tuple's FQDN string looking for the longest suffix that matches any TLD.
+        // Back up one label, and that's what gets copied to the output domain field.
+        // If nothing matches, set the output domain field to the empty string.
+
+        const char *ts = NULL;
+        const char *ds = NULL;
+
+        {
+            mutex_[tldsRSel_].lock();
+
+            if(!firstListLoaded_) {
+                ProcessingElement &pe = getPE();
+
+                SPLAPPTRC(L_TRACE, "Waiting for the initial TLD list to be loaded in. R="<<tldsRSel_, EXTRACT_DOMAIN);
+
+                while(!firstListLoaded_ && !pe.getShutdownRequested()) {
+                    // We haven't finished reading in a TLD list on the other port.
+                    // We'll just block here forever, waiting for the TLD list.
+                    // That means upstream will be blocked as well, or backpressure if there
+                    // are threaded ports up there.  Seems like the right thing to do though,
+                    // since without a TLD list, we're just going to claim all domains are invalid
+                    // anyway.
+                    /// @TODO Maybe a parameter on the operator to do this vs just mark them all
+                    /// invalid?
+                    // Sleep for a ms or so.  Doesn't really matter, just something to keep us
+                    // from soaking up a core while we wait.
+                    mutex_[tldsRSel_].unlock();
+                    pe.blockUntilShutdownRequest(0.001);
+                    mutex_[tldsRSel_].lock();
+                }
+
+                if(firstListLoaded_) {
+                    SPLAPPTRC(L_TRACE, "Initial TLD list is loaded.  We can proceed. R="<<tldsRSel_, EXTRACT_DOMAIN);
+                }
+            }
+
+            for(const char *p = fqdn.c_str(); p && *p; ) {
+                // Check the suffix starting at p to see if it is a TLD
+                if(tlds_[tldsRSel_]->count(p)) {
+                    // Looks like its a TLD!
+                    ts = p;
+                    break;
+                }
+
+                // Probably not a TLD
+                ds = p;
+                p = ::index(p, '.');
+                if(p) {
+                    // Move past the dot.  This might put us at the \0 null terminator, but that's ok, and will be handled fine.
+                    ++p;
+                }
+            }
+
+            mutex_[tldsRSel_].unlock();
+        }
+
+        if(!ts) {
+            // Rather than allow a NULL ptr, set ts (and thus ds, eventually) to the \0 at the end of fqdn.c_str().
+            ts = fqdn.c_str() + fqdn.length();
+            ds = ts;
+            SPLAPPTRC(L_TRACE, "No TLD found.", EXTRACT_DOMAIN);
+        } else {
+            SPLAPPTRC(L_TRACE, "Found TLD: " << std::string(ts), EXTRACT_DOMAIN);
+        }
+
+        if(!ds) {
+            // If no domain, just use the TLD itself, since that's apparently what was being questioned, anyway.
+            ds = ts;
+            SPLAPPTRC(L_TRACE, "No separate domain found.  Just using TLD.", EXTRACT_DOMAIN);
+        } else if(ds != ts) {
+            SPLAPPTRC(L_TRACE, "Found a separate domain: " << std::string(ds, ts - ds - 1), EXTRACT_DOMAIN);
+        }
+
+        if(*ds) {
+            // We have something set here, so use the entire domain+TLD for this field
+            SPLAPPTRC(L_TRACE, "Setting output field to: " << std::string(ds), EXTRACT_DOMAIN);
+            iport$0.set_<%=$outputDomainAttr%>(ds);
+        } else {
+            // No domain/TLD found.
+<% if($blankOnInvalid) { %>
+            // blankOnInvalidTLD is set, so force the field to empty (ds points to the \0, so that will work fine)
+            SPLAPPTRC(L_TRACE, "Setting output field to blank: " << std::string(ds), EXTRACT_DOMAIN);
+            iport$0.set_<%=$outputDomainAttr%>(ds);
+<% } else { %>
+            // blankOnInvalidTLD is NOT set, so use the full fqdn instead
+            SPLAPPTRC(L_TRACE, "Setting output field to full FQDN: " << fqdn, EXTRACT_DOMAIN);
+            iport$0.set_<%=$outputDomainAttr%>(fqdn);
+<% } %>
+        }
+
+        submit(iport$0, 0);
+    }
+}
+
+// Tuple processing for non-mutating ports
+void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
+    SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> process() non-mutating.", EXTRACT_DOMAIN);
+    if(port == 1) {
+        const IPort1Type& iport$1 = tuple;
+
+        SPLAPPTRC(L_WARN, "Process non-mutating, port 1.", EXTRACT_DOMAIN);
+
+        AutoPortMutex amW(mutex_[tldsWSel_], *this);
+
+        tlds_[tldsWSel_]->insert(<%=$inputPort1CppName%>.get_<%=$tldAttribute%>());
+
+        return;
+    }
+}
+
+// Punctuation processing
+void MY_OPERATOR::process(Punctuation const & punct, uint32_t port) {
+    SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> process() punctuation.", EXTRACT_DOMAIN);
+
+    if(port == 1) {
+        if(punct==Punctuation::WindowMarker) {
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() punctuation: window.", EXTRACT_DOMAIN);
+
+            // Take both the R & W mutexes so we can close out the current filter list
+            // and swap lists atomically. This is the very uncommon case
+            // so the locking overhead is not important.
+            // However, we first grab just the writer's mutex,
+            // to avoid slowing down tuple processing.
+            mutex_[tldsWSel_].lock();
+
+            // Ok, all ready to do the swap, so grab the reader mutex as well now.
+            mutex_[tldsRSel_].lock();
+
+            firstListLoaded_ = true;
+
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() sending Window punctuation out port 0", EXTRACT_DOMAIN);
+            submit(Punctuation::WindowMarker, 0);
+
+            size_t tmpList = tldsWSel_;
+            tldsWSel_ = tldsRSel_;
+            tldsRSel_ = tmpList;
+
+            // Drop the lock for the _new_ reader's tld set (was the writer's tld set, when locked)
+            mutex_[tldsRSel_].unlock();
+
+            // At this point, we've already swapped, so tldsWSel points to the old set we were using,
+            // which should now be cleared before new stuff goes in it.
+            tlds_[tldsWSel_]->clear();
+
+            // Finally, drop the new writer's tld set lock (was the reader's tld set, when locked)
+            // so new tld files can be read in (eventually)
+            mutex_[tldsWSel_].unlock();
+
+        } else if(punct==Punctuation::FinalMarker) {
+            SPLAPPTRC(L_WARN, "<%=$myOperatorKind%> process() punctuation: final.", EXTRACT_DOMAIN);
+        }
+    }
+}
+
+
+<%SPL::CodeGen::implementationEpilogue($model);%>
+

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/ExtractDomain/ExtractDomain_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/ExtractDomain/ExtractDomain_cpp.cgt
@@ -116,7 +116,7 @@ void MY_OPERATOR::process(Tuple & tuple, uint32_t port) {
             if(!firstListLoaded_) {
                 ProcessingElement &pe = getPE();
 
-                SPLAPPTRC(L_TRACE, "Waiting for the initial TLD list to be loaded in. R="<<tldsRSel_, EXTRACT_DOMAIN);
+                SPLAPPTRC(L_WARN, "Waiting for the initial TLD list to be loaded in. R="<<tldsRSel_, EXTRACT_DOMAIN);
 
                 while(!firstListLoaded_ && !pe.getShutdownRequested()) {
                     // We haven't finished reading in a TLD list on the other port.
@@ -135,7 +135,7 @@ void MY_OPERATOR::process(Tuple & tuple, uint32_t port) {
                 }
 
                 if(firstListLoaded_) {
-                    SPLAPPTRC(L_TRACE, "Initial TLD list is loaded.  We can proceed. R="<<tldsRSel_, EXTRACT_DOMAIN);
+                    SPLAPPTRC(L_WARN, "Initial TLD list is loaded.  We can proceed. R="<<tldsRSel_, EXTRACT_DOMAIN);
                 }
             }
 
@@ -203,7 +203,7 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
     if(port == 1) {
         const IPort1Type& iport$1 = tuple;
 
-        SPLAPPTRC(L_WARN, "Process non-mutating, port 1.", EXTRACT_DOMAIN);
+        SPLAPPTRC(L_TRACE, "Process non-mutating, port 1.", EXTRACT_DOMAIN);
 
         AutoPortMutex amW(mutex_[tldsWSel_], *this);
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/ExtractDomain/ExtractDomain_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/ExtractDomain/ExtractDomain_h.cgt
@@ -1,0 +1,45 @@
+<%
+## Copyright (C) 2017  International Business Machines Corporation
+## All Rights Reserved
+%>
+
+/* Additional includes go here */
+#include <sys/types.h>
+
+<%SPL::CodeGen::headerPrologue($model);%>
+
+class MY_OPERATOR : public MY_BASE_OPERATOR {
+public:
+  // Constructor
+  MY_OPERATOR();
+
+  // Destructor
+  virtual ~MY_OPERATOR(); 
+
+  // Notify port readiness
+  void allPortsReady(); 
+
+  // Notify pending shutdown
+  void prepareToShutdown(); 
+    
+  void process(Tuple & tuple, uint32_t port);
+    
+  // Tuple processing for non-mutating ports
+  void process(Tuple const & tuple, uint32_t port);
+
+  // Punctuation processing
+  void process(Punctuation const & punct, uint32_t port);
+  
+private:
+  typedef std::tr1::unordered_set<std::string> TLDSet;
+
+  // Members
+  SPL::Mutex mutex_[2] ;
+  TLDSet *tlds_[2];
+  size_t tldsRSel_;
+  size_t tldsWSel_;
+  bool firstListLoaded_;
+}; 
+
+<%SPL::CodeGen::headerEpilogue($model);%>
+

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/SimpleExtractDomain.spl
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/SimpleExtractDomain.spl
@@ -1,0 +1,31 @@
+namespace com.ibm.streamsx.network.domains;
+
+public composite SimpleExtractDomain(input DomainNamesStream; output OutputStream) {
+    param
+        attribute $domainNameAttr;
+        attribute $outputAttr;
+        expression<rstring> $tldsDir;
+        expression<rstring> $tldsFilenamePattern;
+        expression<boolean> $blankOnInvalidTLD: true;
+
+    graph
+        stream<rstring filepath> FilepathFilterStream as Out = DirectoryScan() {
+            param
+                directory: $tldsDir;
+                pattern: $tldsFilenamePattern;
+            output Out:
+                filepath = FullPath();
+        }
+
+        stream<rstring line> TLDStream = FileSource(FilepathFilterStream) {
+            param
+                format: line;
+        }
+
+        stream<DomainNamesStream> OutputStream = ExtractDomain(DomainNamesStream; TLDStream) {
+            param
+                inputFQDNAttr: $domainNameAttr;
+                outputDomainAttr: $outputAttr;
+                blankOnInvalidTLD: $blankOnInvalidTLD;
+        }
+}

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/TestExtractDomain.spl
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/TestExtractDomain.spl
@@ -3,14 +3,6 @@ namespace com.ibm.streamsx.network.domains;
 use com.ibm.streamsx.network.domains::*;
 
 composite TestExtractDomain {
-//    param
-//        expression <uint32>  $iterations     : (uint32)getSubmissionTimeValue("iterations", "1000");
-//        expression <uint64>  $expectedSetSize : (uint64)getSubmissionTimeValue("expectedSetSize", "1000");
-//        expression <float64>  $collisionRate     : (float64)getSubmissionTimeValue("collisionRate","0.1");
-//        expression <float64>  $metricsInterval     : (float64)getSubmissionTimeValue("metricsInterval","60");
-//        expression <uint64> $rotationTupleCount : (uint64)getSubmissionTimeValue("rotationTupleCount", "0");
-//        expression <float64> $prefillRatio : (float64)getSubmissionTimeValue("prefillRatio", "0.0");
-
 
     graph
 
@@ -18,7 +10,6 @@ composite TestExtractDomain {
         param
             file: "testDomains.txt";
             format: line;
-//            initDelay: 15.0;
 
         output
             InputStream: domain="";

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/TestExtractDomain.spl
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.domains/TestExtractDomain.spl
@@ -1,0 +1,42 @@
+namespace com.ibm.streamsx.network.domains;
+
+use com.ibm.streamsx.network.domains::*;
+
+composite TestExtractDomain {
+//    param
+//        expression <uint32>  $iterations     : (uint32)getSubmissionTimeValue("iterations", "1000");
+//        expression <uint64>  $expectedSetSize : (uint64)getSubmissionTimeValue("expectedSetSize", "1000");
+//        expression <float64>  $collisionRate     : (float64)getSubmissionTimeValue("collisionRate","0.1");
+//        expression <float64>  $metricsInterval     : (float64)getSubmissionTimeValue("metricsInterval","60");
+//        expression <uint64> $rotationTupleCount : (uint64)getSubmissionTimeValue("rotationTupleCount", "0");
+//        expression <float64> $prefillRatio : (float64)getSubmissionTimeValue("prefillRatio", "0.0");
+
+
+    graph
+
+        stream<rstring fqdn, rstring domain> InputStream = FileSource() {
+        param
+            file: "testDomains.txt";
+            format: line;
+//            initDelay: 15.0;
+
+        output
+            InputStream: domain="";
+        }
+
+        stream<rstring fqdn, rstring domain> Extracted = SimpleExtractDomain(InputStream) {
+        param
+            tldsDir: "";
+            tldsFilenamePattern: "^ascii_tlds$";
+            domainNameAttr: fqdn;
+            outputAttr: domain;
+            blankOnInvalidTLD: false;
+        }
+
+        () as LogSink = Custom(Extracted) {
+            logic onTuple Extracted: {
+                printStringLn((rstring)"[" + fqdn + "] [" + domain + "]");
+            }
+        }
+
+}


### PR DESCRIPTION
This operator efficiently converts a FQDN to just the domain and TLD.  The native operator (ExtractDomain) supports live/concurrent updates to the TLD list, and blocks processing tuples until the initial TLD list is loaded and processed.  The higher-level composite (SimpleExtractDomain) uses the native operator and simple DirectoryScan/FileSource to handle detecting changes to the TLD list and sending the new TLDs to the native operator.
