### PR TITLE
Dpdk updates and improved IPFilter

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/IPFilter/IPFilter_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.filter/IPFilter/IPFilter_cpp.cgt
@@ -116,18 +116,19 @@ void MY_OPERATOR::process(Tuple const & tuple, uint32_t port) {
 
             SPLAPPTRC(L_WARN, "Process() non-mutating, port 1.  ipv4FilterAddr = " << ipv4Addr, IP_FILTER);
 
-            SPL::list<SPL::uint32> addrList = getAllAddressesInNetworkInt(ipv4Addr);
-            SPLAPPTRC(L_WARN, "Process() non-mutating, port 1.  Adding count = " << addrList.size(), IP_FILTER);
-
             AutoPortMutex amW(mutex_[ip4ListWSel_], *this);
-            SPL::list<SPL::uint32>::const_iterator it;
-            for(it = addrList.begin(); it != addrList.end(); ++it) {
-                ip4List_[ip4ListWSel_]->insert(*it);
+            SPL::uint32 addrStart, addrEnd;
+            SPL::uint32 addrRange = getAddressRangeInNetworkInt(ipv4Addr, addrStart, addrEnd);
+            SPLAPPTRC(L_ERROR, "Process() non-mutating, port 1.  Adding count = " << addrRange << ", start = " << std::hex << addrStart << ", end = " << std::hex << addrEnd, IP_FILTER);
+            for(SPL::uint32 b = addrStart; b < addrEnd; b++) {
+                ip4List_[ip4ListWSel_]->insert(b);
                 SPLAPPTRC(L_TRACE, "IPv4 filter: " << "adding: " << 
-                        convertIPV4AddressNumericToString(*it) << 
-                        "(" << *it << ")", IP_FILTER);
+                        convertIPV4AddressNumericToString(b) << 
+                        "(" << b << ")", IP_FILTER);
             }
+            SPLAPPTRC(L_ERROR, "Process() non-mutating, port 1.  Done Adding", IP_FILTER);
             return;
+
         }
     <%}%>
 }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.ipv4/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.ipv4/native.function/function.xml
@@ -45,6 +45,10 @@
         <function:prototype>public list&lt;uint32> getAllAddressesInNetworkInt(rstring networkCIDR)</function:prototype>
       </function:function>
       <function:function>
+        <function:description sampleUri="">Returns the range of IP addresses in the network as a start and end values. The *networkCIDR* argument must be in CIDR format (i.e. 0.0.0.0/24), otherwise an empty range will be reported.</function:description>
+        <function:prototype>public uint32 getAddressRangeInNetworkInt(rstring networkCIDR, uint32 addressStart, uint32 addressEnd)</function:prototype>
+      </function:function>
+      <function:function>
         <function:description>Returns `true` if a valid IPv4 address was provided and the IP address is not a reserved address. Also returns `true` if the IP address is a &quot;6to4 Relay Anycast&quot; address, since these can be globally routed (RFC6890). In all other cases, will return `false`.</function:description>
         <function:prototype>public boolean isGlobal(rstring ip)</function:prototype>
       </function:function>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
@@ -183,7 +183,7 @@ To verify that 'hugepages' have been allocated, enter this command at a prompt:
 DPDK requires several environment variables. 
 To set them, enter these commands at a prompt, or append them to your $HOME/.bashrc script:
 
-    export RTE_SDK=$HOME/dpdk-17.02.1
+    export RTE_SDK=$HOME/dpdk-17.11.3
     [[ $( uname -m ) == &quot;x86_64&quot; ]] &amp;&amp; export RTE_TARGET=x86_64-native-linuxapp-gcc
     [[ $( uname -m ) == &quot;ppc64le&quot; ]] &amp;&amp; export RTE_TARGET=ppc_64-power8-linuxapp-gcc
     [[ -x /usr/sbin/lspci ]] &amp;&amp; export DPDK_DEVICE=$( /usr/sbin/lspci | grep -i mellanox | gawk '{print $1}' )
@@ -199,15 +199,15 @@ To verify that the environment variables are set, enter this command at a prompt
 
 **installing the DPDK library**
 
-The PacketDPDKSource operator depends upon DPDK library version 17.02.1, available from
+The PacketDPDKSource operator depends upon DPDK library version 17.11.3, available from
 [http://dpdk.org]. The library must be configured for your machine and ethernet adapter,
 and compiled from source code.
 
 To get the DPDK source code, enter these lines at a command prompt:
 
     mkdir -p $RTE_SDK
-    wget http://fast.dpdk.org/rel/dpdk-17.02.1.tar.xz
-    tar -x -v -f dpdk-17.02.1.tar.xz -C $RTE_SDK --strip-components=1
+    wget http://fast.dpdk.org/rel/dpdk-17.11.3.tar.xz
+    tar -x -v -f dpdk-17.11.3.tar.xz -C $RTE_SDK --strip-components=1
 
 To configure DPDK for your machine, enter these lines at a command prompt:
 

--- a/com.ibm.streamsx.network/impl/include/IPv4AddressFunctions.h
+++ b/com.ibm.streamsx.network/impl/include/IPv4AddressFunctions.h
@@ -497,6 +497,21 @@ namespace com { namespace ibm { namespace streamsx { namespace network { namespa
             return addresses;
       }
 
+      static SPL::uint32 getAddressRangeInNetworkInt(SPL::rstring const & networkCIDR, SPL::uint32 &addressStart, SPL::uint32 &addressEnd)
+      {
+            network_cidr resultCIDR;
+            addressStart = 0; addressEnd = 0;
+            if(parseNetworkCIDR_(networkCIDR, resultCIDR) == false) return 0;
+
+            dec_network_range range;
+            GET_DEC_NET_RANGE(resultCIDR, range);
+
+            addressStart = range.network_start;
+            addressEnd = range.network_end;
+
+            return (range.network_end - range.network_start);
+      }
+
       static SPL::boolean isGlobal(SPL::rstring const & ip)
       {
             return isInNetwork("192.88.99.0/24", ip) || !isReserved(ip);

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/port-tool/port-tool.c
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/port-tool/port-tool.c
@@ -16,6 +16,7 @@
 #include <rte_cycles.h>
 #include <rte_eal.h>
 #include <rte_errno.h>
+#include <rte_bus_pci.h>
 #include <rte_ethdev.h>
 #include <rte_lcore.h>
 #include <rte_mbuf.h>

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/init.c
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/init.c
@@ -13,6 +13,7 @@
 #include <rte_cycles.h>
 #include <rte_eal.h>
 #include <rte_errno.h>
+#include <rte_bus_pci.h>
 #include <rte_ethdev.h>
 #include <rte_lcore.h>
 #include <rte_mbuf.h>

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/streams_source.c
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/streams_source.c
@@ -286,7 +286,7 @@ int streams_dpdk_init(const char* buffersizes) {
     rte_timer_subsystem_init();
 #endif
 
-    rte_set_log_level(8); 
+    rte_log_set_global_level(8); 
 
     uint32_t nb_ports = rte_eth_dev_count();
     if (nb_ports == 0) {

--- a/samples/SamplePacketDPDKSource/script/setupDPDK.sh
+++ b/samples/SamplePacketDPDKSource/script/setupDPDK.sh
@@ -128,8 +128,8 @@ grep -i -h hugepages /sys/devices/system/node/node*/meminfo
 
 step "get DPDK source code, if necessary ..."
 [[ -d $RTE_SDK ]] || mkdir -p $RTE_SDK || die "sorry, could not create directory $RTE_SDK"
-[[ -f dpdk-17.02.1.tar.xz ]] || wget http://fast.dpdk.org/rel/dpdk-17.02.1.tar.xz || die "sorry, could not get DPDK source code from http://fast.dpdk.org/rel/dpdk-17.02.1.tar.xz"
-[[ -f $RTE_SDK/Makefile ]] || tar -x -v -f dpdk-17.02.1.tar.xz -C $RTE_SDK --strip-components=1 || die "sorry, could not unpack DPDK source code"
+[[ -f dpdk-17.11.3.tar.xz ]] || wget http://fast.dpdk.org/rel/dpdk-17.11.3.tar.xz || die "sorry, could not get DPDK source code from http://fast.dpdk.org/rel/dpdk-17.11.3.tar.xz"
+[[ -f $RTE_SDK/Makefile ]] || tar -x -v -f dpdk-17.11.3.tar.xz -C $RTE_SDK --strip-components=1 || die "sorry, could not unpack DPDK source code"
 
 # patch old DPDK 2.2.0 source code for RHEL/CentOS 7.3
 


### PR DESCRIPTION
- Support for newer version of DPDK, in support of RHEL7.4 and forward.
- Additional CIDR functions to determine the range of addresses covered.
- Improved IPFilter performance by avoiding needless creation of local list of IP addresses