### PR TITLE
Some major performance enhancements for the PacketDPDKSource

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource.xml
@@ -396,6 +396,25 @@ The default value is 'false'.
     </parameter>
 
     <parameter>
+      <name>rateLimit</name>
+      <description> 
+
+This optional parameter takes an expression of type 'float64'
+that specifies the maximum number of times per second the RATE_LIMITED() 
+function returns false.  This can be used to limit the rate of packets sent 
+to an output port when used in a filter expression.
+
+The default value is '1000.0'.
+
+      </description>
+      <optional>true</optional>
+      <rewriteAllowed>true</rewriteAllowed>
+      <expressionMode>Expression</expressionMode>
+      <type>float64</type>
+      <cardinality>1</cardinality>
+    </parameter>
+
+    <parameter>
       <name>jMirrorCheck</name>
       <description> 
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
@@ -230,8 +230,8 @@ void MY_OPERATOR::packetProcess(uint8_t *packet, uint32_t length, uint64_t tscTi
 
   // Start a prefetch of the packet data.  This was found to help
   // in some situations, but results will vary.
-  __builtin_prefetch((void *)packet, 0, 0);
-  __builtin_prefetch((void *)((uint64_t)packet + packetLen), 0, 0);
+//  __builtin_prefetch((void *)packet, 0, 0);
+//  __builtin_prefetch((void *)((uint64_t)packet + packetLen), 0, 0);
 
   // get current time in microseconds
   struct timespec ts; 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_cpp.cgt
@@ -34,6 +34,7 @@ my $buffersizes = $model->getParameterByName("buffersizes") ? $model->getParamet
 my $jMirrorCheck = $model->getParameterByName("jMirrorCheck") ? $model->getParameterByName("jMirrorCheck")->getValueAt(0)->getCppExpression() : 0;
 my $promiscuous = $model->getParameterByName("promiscuous") ? $model->getParameterByName("promiscuous")->getValueAt(0)->getCppExpression() : 0;
 my $metricsInterval = $model->getParameterByName("metricsInterval") ? $model->getParameterByName("metricsInterval")->getValueAt(0)->getCppExpression() : 10.0;
+my $rateLimit = $model->getParameterByName("rateLimit") ? $model->getParameterByName("rateLimit")->getValueAt(0)->getCppExpression() : 1000.0;
 
 # special handling for 'outputFilters' parameter, which may include SPL functions that reference input tuples indirectly
 my $outputFilterParameter = $model->getParameterByName("outputFilters");
@@ -94,6 +95,12 @@ MY_OPERATOR::MY_OPERATOR() {
   const bool promiscuous = <%=$promiscuous%>;
   jMirrorCheck = <%=$jMirrorCheck%>;
   metricsInterval = <%=$metricsInterval%>;
+
+  // Set up rate limiter parameters.  This approach scales to 1M pps, or 1 per usec and then
+  // goes unlimited. 
+  rateLimit = <%=$rateLimit%>;
+  rateLimitLastTime = 0;
+  rateLimitPeriodUsec = (uint64_t)((1.0 / rateLimit) * 1000000.0); 
 
   // initialize operator state variables
   dpdkThreadID = metricsThreadID = 0;

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_h.cgt
@@ -99,6 +99,9 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
   double now, then;  
   bool metricsUpdate;
   bool realMetricsUpdate;
+  double    rateLimit;
+  uint64_t  rateLimitLastTime;
+  uint64_t  rateLimitPeriodUsec;
 
   // ----------- network header parser ----------
   
@@ -371,7 +374,16 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
   inline __attribute__((always_inline))
   SPL::int32 DNS_INCOMPATIBLE_FLAGS() { return parser.incompatibleFlags(); }
 
-
+  inline __attribute__((always_inline))
+  SPL::boolean RATE_LIMITED() { 
+    // This gets the recorded time when the last packet came in which is close enough for what we need here.
+    uint64_t currentTime = ((uint64)CAPTURE_SECONDS()*1000000ul)+(uint64)CAPTURE_MICROSECONDS();
+    if(currentTime >= (rateLimitLastTime + rateLimitPeriodUsec)) {
+        rateLimitLastTime = currentTime;
+        return false;
+    }
+    return true; 
+  }
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketDPDKSource/DNSPacketDPDKSource_h.cgt
@@ -153,6 +153,15 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
   SPL::boolean metricsUpdated() { return then && metricsUpdate; }
 
   inline __attribute__((always_inline))
+  SPL::uint64 packetsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalMaxQueueDepthSW() { return 0; }
+
+  inline __attribute__((always_inline))
   SPL::uint32 CAPTURE_SECONDS() { return captureSeconds; }
 
   inline __attribute__((always_inline))

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketFileSource/DNSPacketFileSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketFileSource/DNSPacketFileSource.xml
@@ -410,6 +410,26 @@ The default value is '10.0'.
         <type>float64</type>
         <cardinality>1</cardinality>
       </parameter>
+
+    <parameter>
+      <name>rateLimit</name>
+      <description>
+
+This optional parameter takes an expression of type 'float64'
+that specifies the maximum number of times per second the RATE_LIMITED()
+function returns false.  This can be used to limit the rate of packets sent
+to an output port when used in a filter expression.
+
+The default value is '1000.0'.
+
+      </description>
+      <optional>true</optional>
+      <rewriteAllowed>true</rewriteAllowed>
+      <expressionMode>Expression</expressionMode>
+      <type>float64</type>
+      <cardinality>1</cardinality>
+    </parameter>
+
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketFileSource/DNSPacketFileSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketFileSource/DNSPacketFileSource_cpp.cgt
@@ -28,6 +28,7 @@ my $initDelay = $model->getParameterByName("initDelay") ? $model->getParameterBy
 my $processorAffinity = $model->getParameterByName("processorAffinity") ? $model->getParameterByName("processorAffinity")->getValueAt(0)->getCppExpression() : -1;
 my $jMirrorCheck = $model->getParameterByName("jMirrorCheck") ? $model->getParameterByName("jMirrorCheck")->getValueAt(0)->getCppExpression() : 0;
 my $metricsInterval = $model->getParameterByName("metricsInterval") ? $model->getParameterByName("metricsInterval")->getValueAt(0)->getCppExpression() : 10.0;
+my $rateLimit = $model->getParameterByName("rateLimit") ? $model->getParameterByName("rateLimit")->getValueAt(0)->getCppExpression() : 1000.0;
 
 # special handling for 'outputFilters' parameter, which may include SPL functions that reference input tuples indirectly
 my $outputFilterParameter = $model->getParameterByName("outputFilters");
@@ -83,6 +84,12 @@ MY_OPERATOR::MY_OPERATOR()
   processorAffinity = <%=$processorAffinity%>;
   jMirrorCheck = <%=$jMirrorCheck%>;
   metricsInterval = <%=$metricsInterval%>;
+
+  // Set up rate limiter parameters.  This approach scales to 1M pps, or 1 per usec and then
+  // goes unlimited. 
+  rateLimit = <%=$rateLimit%>;
+  rateLimitLastTime = 0;
+  rateLimitPeriodUsec = (uint64_t)((1.0 / rateLimit) * 1000000.0);
 
   // initialize operator state variables
   startTimeInNanoseconds = SPL::Functions::Time::getCPUCounterInNanoSeconds();

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketFileSource/DNSPacketFileSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketFileSource/DNSPacketFileSource_h.cgt
@@ -88,6 +88,9 @@ public:
   uint64_t byteCounter, byteCounterNow, byteCounterThen;
   bool metricsUpdate;
   boolean done;
+  double    rateLimit;
+  uint64_t  rateLimitLastTime;
+  uint64_t  rateLimitPeriodUsec;
 
   // ----------- libpcap-specific variables ----------
 
@@ -144,6 +147,15 @@ public:
 
   inline __attribute__((always_inline))
   SPL::boolean metricsUpdated() { return then && metricsUpdate; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 packetsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalMaxQueueDepthSW() { return 0; }
 
   inline __attribute__((always_inline))
   SPL::uint32 CAPTURE_SECONDS() { return pcapHeader->ts.tv_sec; }
@@ -364,7 +376,16 @@ public:
   inline __attribute__((always_inline))
   SPL::int32 DNS_INCOMPATIBLE_FLAGS() { return parser.incompatibleFlags(); }
 
-
+  inline __attribute__((always_inline))
+  SPL::boolean RATE_LIMITED() {
+    // This gets the recorded time when the last packet came in which is close enough for what we need here.
+    uint64_t currentTime = ((uint64)CAPTURE_SECONDS()*1000000ul)+(uint64)CAPTURE_MICROSECONDS();
+    if(currentTime >= (rateLimitLastTime + rateLimitPeriodUsec)) {
+        rateLimitLastTime = currentTime;
+        return false;
+    }
+    return true;
+  }
 
   // ------------------------------------------------------------------------------------------
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketLiveSource/DNSPacketLiveSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketLiveSource/DNSPacketLiveSource.xml
@@ -619,6 +619,26 @@ The default value is '10.0'.
         <type>float64</type>
         <cardinality>1</cardinality>
       </parameter>
+
+    <parameter>
+      <name>rateLimit</name>
+      <description>
+
+This optional parameter takes an expression of type 'float64'
+that specifies the maximum number of times per second the RATE_LIMITED()
+function returns false.  This can be used to limit the rate of packets sent
+to an output port when used in a filter expression.
+
+The default value is '1000.0'.
+
+      </description>
+      <optional>true</optional>
+      <rewriteAllowed>true</rewriteAllowed>
+      <expressionMode>Expression</expressionMode>
+      <type>float64</type>
+      <cardinality>1</cardinality>
+    </parameter>
+
     </parameters>
     <inputPorts/>
     <outputPorts>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketLiveSource/DNSPacketLiveSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketLiveSource/DNSPacketLiveSource_cpp.cgt
@@ -32,6 +32,7 @@ my $jMirrorCheck = $model->getParameterByName("jMirrorCheck") ? $model->getParam
 my $timeout = $model->getParameterByName("timeout") ? $model->getParameterByName("timeout")->getValueAt(0)->getCppExpression() : 0;
 my $inputFilter = $model->getParameterByName("inputFilter") ? $model->getParameterByName("inputFilter")->getValueAt(0)->getCppExpression() : undef;
 my $metricsInterval = $model->getParameterByName("metricsInterval") ? $model->getParameterByName("metricsInterval")->getValueAt(0)->getCppExpression() : 10.0;
+my $rateLimit = $model->getParameterByName("rateLimit") ? $model->getParameterByName("rateLimit")->getValueAt(0)->getCppExpression() : 1000.0;
 
 # special handling for 'outputFilters' parameter, which may include SPL functions that reference input tuples indirectly
 my $outputFilterParameter = $model->getParameterByName("outputFilters");
@@ -83,6 +84,12 @@ MY_OPERATOR::MY_OPERATOR()
   timeout = <%=$timeout%>;
   inputFilter = <%= $inputFilter ? $inputFilter : '""' %>;
   metricsInterval = <%=$metricsInterval%>;
+
+  // Set up rate limiter parameters.  This approach scales to 1M pps, or 1 per usec and then
+  // goes unlimited. 
+  rateLimit = <%=$rateLimit%>;
+  rateLimitLastTime = 0;
+  rateLimitPeriodUsec = (uint64_t)((1.0 / rateLimit) * 1000000.0);
 
   // initialize operator state variables
   pcapThreadID = metricsThreadID = 0;

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketLiveSource/DNSPacketLiveSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/DNSPacketLiveSource/DNSPacketLiveSource_h.cgt
@@ -83,6 +83,9 @@ private:
   uint64_t packetCounter, packetCounterNow, packetCounterThen;
   uint64_t byteCounter, byteCounterNow, byteCounterThen;
   bool metricsUpdate;
+  double    rateLimit;
+  uint64_t  rateLimitLastTime;
+  uint64_t  rateLimitPeriodUsec;
 
   // ----------- libpcap-specific variables ----------
 
@@ -139,6 +142,15 @@ private:
 
   inline __attribute__((always_inline))
   SPL::boolean metricsUpdated() { return then && metricsUpdate; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 packetsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalMaxQueueDepthSW() { return 0; }
 
   inline __attribute__((always_inline))
   SPL::uint32 CAPTURE_SECONDS() { return pcapHeader->ts.tv_sec; }
@@ -359,6 +371,16 @@ private:
   inline __attribute__((always_inline))
   SPL::int32 DNS_INCOMPATIBLE_FLAGS() { return parser.incompatibleFlags(); }
 
+  inline __attribute__((always_inline))
+  SPL::boolean RATE_LIMITED() {
+    // This gets the recorded time when the last packet came in which is close enough for what we need here.
+    uint64_t currentTime = ((uint64)CAPTURE_SECONDS()*1000000ul)+(uint64)CAPTURE_MICROSECONDS();
+    if(currentTime >= (rateLimitLastTime + rateLimitPeriodUsec)) {
+        rateLimitLastTime = currentTime;
+        return false;
+    }
+    return true;
+  }
 
   // ------------------------------------------------------------------------------------------
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/native.function/function.xml
@@ -229,6 +229,36 @@ and returns `false` for all subsequent tuples produced in the same metrics inter
           <function:function>
             <function:description>
 
+This function returns the total number of packets dropped by the software packet receive queue (if implemented).
+Otherwise, returns 0.
+
+            </function:description>
+            <function:prototype>public uint64 packetsDroppedSW()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
+This function returns the number of packets dropped by the software packet receive queue (if implemented) in the
+most recent metrics interval.  Otherwise, returns 0.
+
+            </function:description>
+            <function:prototype>public uint64 metricsIntervalPacketsDroppedSW()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
+This function returns the software receive queue (if implemented) high water mark from the most recent metrics interval.
+Otherwise, returns 0.
+
+            </function:description>
+            <function:prototype>public uint64 metricsIntervalMaxQueueDepthSW()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
 This function returns the number of seconds since the beginning of the Unix epoch
 (midnight on January 1st, 1970 in Greenwich, England) until the current packet was captured,
 according to the system clock on the machine that captured it.

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.dns/native.function/function.xml
@@ -897,6 +897,14 @@ if it has one, or zero otherwise.
         <function:prototype>public int32 DNS_INCOMPATIBLE_FLAGS()</function:prototype>
       </function:function>
 
+      <function:function>
+        <function:description>
+        This function returns false when an amount of time between packets has passed such that
+        the rate is limited to the value given in the rateLimit paramater.
+        </function:description>
+        <function:prototype>public boolean RATE_LIMITED()</function:prototype>
+      </function:function>
+
     </function:functions>
   </function:functionSet>
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
@@ -189,8 +189,8 @@ private:
   SPL::blob DNS_EXTRA_DATA() { return parser.dnsExtra ? SPL::blob((const unsigned char*)parser.dnsExtra, (uint64_t)(parser.dnsEnd-parser.dnsExtra)) : SPL::blob(); }
 
   inline __attribute__((always_inline))
-  SPL::rstring DNS_ALL_FIELDS(SPL::rstring recordDelimiter, SPL::rstring fieldDelimiter, SPL::rstring subfieldDelimiter, SPL::list<SPL::uint16> rrTypes, SPL::uint64 captureSeconds, SPL::uint32 packetLen, SPL::uint32 srcAddr, SPL::uint32 dstAddr, SPL::uint16 srcUdpPort, SPL::uint16 dstUdpPort) 
-    { return flattener.dnsAllFields(captureSeconds, packetLen, srcAddr, dstAddr, srcUdpPort, dstUdpPort, parser, recordDelimiter.c_str(), fieldDelimiter.c_str(), subfieldDelimiter.c_str(), rrTypes); }
+  SPL::rstring DNS_ALL_FIELDS(SPL::rstring recordDelimiter, SPL::rstring fieldDelimiter, SPL::rstring subfieldDelimiter, SPL::list<SPL::uint16> rrTypes, SPL::uint64 captureSeconds, SPL::uint32 packetLen, SPL::uint32 srcAddr, SPL::uint32 dstAddr, SPL::uint16 srcUdpPort, SPL::uint16 dstUdpPort, SPL::uint8 protocol, SPL::uint32 payloadLength, SPL::uint16 mac16) 
+    { return flattener.dnsAllFields(captureSeconds, packetLen, srcAddr, dstAddr, srcUdpPort, dstUdpPort, protocol, payloadLength, mac16, parser, recordDelimiter.c_str(), fieldDelimiter.c_str(), subfieldDelimiter.c_str(), rrTypes); }
 
   inline __attribute__((always_inline))
   SPL::int32 DNS_INCOMPATIBLE_FLAGS() { return parser.incompatibleFlags(); }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
@@ -190,7 +190,7 @@ private:
 
   inline __attribute__((always_inline))
   SPL::rstring DNS_ALL_FIELDS(SPL::rstring recordDelimiter, SPL::rstring fieldDelimiter, SPL::rstring subfieldDelimiter, SPL::list<SPL::uint16> rrTypes, SPL::uint64 captureSeconds, SPL::uint32 packetLen, SPL::uint32 srcAddr, SPL::uint32 dstAddr, SPL::uint16 srcUdpPort, SPL::uint16 dstUdpPort, SPL::uint8 protocol, SPL::uint32 payloadLength, SPL::uint16 mac16) 
-    { return flattener.dnsAllFields(captureSeconds, packetLen, srcAddr, dstAddr, srcUdpPort, dstUdpPort, protocol, payloadLength, mac16, parser, recordDelimiter.c_str(), fieldDelimiter.c_str(), subfieldDelimiter.c_str(), rrTypes); }
+    { return flattener.dnsAllFields(captureSeconds, packetLen, htonl(srcAddr), htonl(dstAddr), srcUdpPort, dstUdpPort, protocol, payloadLength, mac16, parser, recordDelimiter.c_str(), fieldDelimiter.c_str(), subfieldDelimiter.c_str(), rrTypes); }
 
   inline __attribute__((always_inline))
   SPL::int32 DNS_INCOMPATIBLE_FLAGS() { return parser.incompatibleFlags(); }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
@@ -6,6 +6,7 @@
 %>
 
 #include "parse/DNSMessageParser.h"
+#include "dns/DNSPacketFlattener.h"
 
 <%SPL::CodeGen::headerPrologue($model);%>
 
@@ -39,9 +40,10 @@ private:
   Mutex processMutex;
   uint64_t tupleCounter;
 
-  // ----------- DNS message parser ----------
+  // ----------- DNS message parser and flattener ----------
 
   DNSMessageParser parser;
+  DNSPacketFlattener flattener;
 
   // ----------- assignment functions for output attributes ----------
 
@@ -185,6 +187,10 @@ private:
 
   inline __attribute__((always_inline))
   SPL::blob DNS_EXTRA_DATA() { return parser.dnsExtra ? SPL::blob((const unsigned char*)parser.dnsExtra, (uint64_t)(parser.dnsEnd-parser.dnsExtra)) : SPL::blob(); }
+
+  inline __attribute__((always_inline))
+  SPL::rstring DNS_ALL_FIELDS(SPL::rstring recordDelimiter, SPL::rstring fieldDelimiter, SPL::rstring subfieldDelimiter, SPL::list<SPL::uint16> rrTypes, SPL::uint64 captureSeconds, SPL::uint32 packetLen, SPL::uint32 srcAddr, SPL::uint32 dstAddr, SPL::uint16 srcUdpPort, SPL::uint16 dstUdpPort) 
+    { return flattener.dnsAllFields(captureSeconds, packetLen, srcAddr, dstAddr, srcUdpPort, dstUdpPort, parser, recordDelimiter.c_str(), fieldDelimiter.c_str(), subfieldDelimiter.c_str(), rrTypes); }
 
   inline __attribute__((always_inline))
   SPL::int32 DNS_INCOMPATIBLE_FLAGS() { return parser.incompatibleFlags(); }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/native.function/function.xml
@@ -1269,7 +1269,7 @@
           record and field delimiters, and for SOA resource records, 
           a subfield delimiter. DNS resource records are selected by specifying DNS types in a list of unsigned 16-bit integers as the fourth parameter of the function.
         </function:description>
-        <function:prototype>public rstring DNS_ALL_FIELDS(rstring, rstring, rstring, list&lt;uint16>, uint64, uint32, uint32, uint32, uint16, uint16)</function:prototype>
+        <function:prototype>public rstring DNS_ALL_FIELDS(rstring, rstring, rstring, list&lt;uint16>, uint64, uint32, uint32, uint32, uint16, uint16, uint8, uint32, uint16)</function:prototype>
       </function:function>
 
       <function:function>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/native.function/function.xml
@@ -1255,7 +1255,8 @@
           fields from the DNS header, and all fields from seleccted DNS resource records, 
           represented as appropriate, separated by the specified
           record and field delimiters, and for SOA resource records, 
-          a subfield delimiter. DNS resource records are selected by specifying DNS types in a list of unsigned 16-bit integers as the fourth parameter of the function.
+          a subfield delimiter. DNS resource records are selected by specifying DNS types
+          in a list of unsigned 16-bit integers as the fourth parameter of the function.
         </function:description>
         <function:prototype>public rstring DNS_ALL_FIELDS(rstring, rstring, rstring, list&lt;uint16>)</function:prototype>
       </function:function>
@@ -1267,7 +1268,10 @@
           fields from the DNS header, and all fields from seleccted DNS resource records, 
           represented as appropriate, separated by the specified
           record and field delimiters, and for SOA resource records, 
-          a subfield delimiter. DNS resource records are selected by specifying DNS types in a list of unsigned 16-bit integers as the fourth parameter of the function.
+          a subfield delimiter. DNS resource records are selected by specifying DNS types
+          in a list of unsigned 16-bit integers as the fourth parameter of the function.
+          Network header fields are passed in directly, since the this operator doesn't have
+          direct access to them.
         </function:description>
         <function:prototype>public rstring DNS_ALL_FIELDS(rstring, rstring, rstring, list&lt;uint16>, uint64, uint32, uint32, uint32, uint16, uint16, uint8, uint32, uint16)</function:prototype>
       </function:function>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/native.function/function.xml
@@ -1262,6 +1262,18 @@
 
       <function:function>
         <function:description>
+          This parser result function returns a string containing 'flattened' representation
+          of the DNS packet, including selected fields from the IP and UDP headers, all 
+          fields from the DNS header, and all fields from seleccted DNS resource records, 
+          represented as appropriate, separated by the specified
+          record and field delimiters, and for SOA resource records, 
+          a subfield delimiter. DNS resource records are selected by specifying DNS types in a list of unsigned 16-bit integers as the fourth parameter of the function.
+        </function:description>
+        <function:prototype>public rstring DNS_ALL_FIELDS(rstring, rstring, rstring, list&lt;uint16>, uint64, uint32, uint32, uint32, uint16, uint16)</function:prototype>
+      </function:function>
+
+      <function:function>
+        <function:description>
           This parser result function returns a non-zero integer to indicate that an encoding error was found while decoding the current packet,
           or zero if no enoding errors were found. The error codes are:
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
@@ -288,6 +288,18 @@ This metric counts the number of packets dropped by the ethernet adapter, as cou
 	  </description>
           <kind>Counter</kind>
         </metric>
+
+       <metric>
+          <name>nBytesReceivedCurrent</name>
+          <description>
+
+This metric counts the number of bytes received by the ethernet adapter,
+as counted by DPDK.
+
+      </description>
+          <kind>Counter</kind>
+       </metric>
+
         <metric>
           <name>nPacketsProcessedCurrent</name>
           <description>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
@@ -318,6 +318,24 @@ This metric counts number of bytes of packet data processed by the operator.
 	  </description>
           <kind>Counter</kind>
         </metric>
+        <metric>
+          <name>nPacketsDroppedSWCurrent</name>
+          <description>
+
+This metric counts number of packets dropped by the initial software queue. 
+
+	  </description>
+          <kind>Counter</kind>
+        </metric>
+        <metric>
+          <name>maxQueueDepthSWCurrent</name>
+          <description>
+
+This metric reports the high water mark of the first software queue. 
+
+	  </description>
+          <kind>Counter</kind>
+        </metric>
       </metrics>
 
       <libraryDependencies>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
@@ -547,6 +547,25 @@ The default value is '10.0'.
         <cardinality>1</cardinality>
       </parameter>
 
+    <parameter>
+      <name>rateLimit</name>
+      <description>
+
+This optional parameter takes an expression of type 'float64'
+that specifies the maximum number of times per second the RATE_LIMITED()
+function returns false.  This can be used to limit the rate of packets sent
+to an output port when used in a filter expression.
+
+The default value is '1000.0'.
+
+      </description>
+      <optional>true</optional>
+      <rewriteAllowed>true</rewriteAllowed>
+      <expressionMode>Expression</expressionMode>
+      <type>float64</type>
+      <cardinality>1</cardinality>
+    </parameter>
+
     </parameters>
 
     <inputPorts/>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource.xml
@@ -406,6 +406,23 @@ To determine which NUMA node your ethernet adapter is connected to, look in the 
       </parameter>
 
       <parameter>
+        <name>dequeueThreadPinning</name>
+        <description>
+This optional parameter specifies a set of logical processor cores to pin the
+internal ring buffer dequeue thread to.  This thread will run at 100% cpu
+utilization as it spins on the ring buffer tail.
+
+By default, this thread runs unpinned.
+        </description>
+        <optional>true</optional>
+        <rewriteAllowed>true</rewriteAllowed>
+        <expressionMode>AttributeFree</expressionMode>
+        <type><![CDATA[list<uint64>]]></type>
+        <cardinality>1</cardinality>
+      </parameter>
+
+
+      <parameter>
         <name>nicPort</name>
         <description>
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -392,7 +392,9 @@ void MY_OPERATOR::processSubmitLoop() {
     SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> processSubmitLoop()", "PacketDPDKSource");
 
     bool shutdown = getPE().getShutdownRequested();
+
     INST_TS(instBuckets_startTime);
+
     while(!shutdown) {
         // In here, try to consume from the ring buffer
         // If we consumed a packet, try for another one

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -42,6 +42,7 @@ my $buffersizes = $model->getParameterByName("buffersizes") ? $model->getParamet
 my $promiscuous = $model->getParameterByName("promiscuous") ? $model->getParameterByName("promiscuous")->getValueAt(0)->getCppExpression() : 0;
 my $jMirrorCheck = $model->getParameterByName("jMirrorCheck") ? $model->getParameterByName("jMirrorCheck")->getValueAt(0)->getCppExpression() : 0;
 my $metricsInterval = $model->getParameterByName("metricsInterval") ? $model->getParameterByName("metricsInterval")->getValueAt(0)->getCppExpression() : 10.0;
+my $rateLimit = $model->getParameterByName("rateLimit") ? $model->getParameterByName("rateLimit")->getValueAt(0)->getCppExpression() : 1000.0;
 
 # special handling for 'outputFilters' parameter, which may include SPL functions that reference input tuples indirectly
 my $outputFilterParameter = $model->getParameterByName("outputFilters");
@@ -107,6 +108,12 @@ MY_OPERATOR::MY_OPERATOR() {
   const bool promiscuous = <%=$promiscuous%>;
   jMirrorCheck = <%=$jMirrorCheck%>;
   metricsInterval = <%=$metricsInterval%>;
+
+  // Set up rate limiter parameters.  This approach scales to 1M pps, or 1 per usec and then
+  // goes unlimited. 
+  rateLimit = <%=$rateLimit%>;
+  rateLimitLastTime = 0;
+  rateLimitPeriodUsec = (uint64_t)((1.0 / rateLimit) * 1000000.0);
 
   // Initialize the DPDK subsystem.
   int rc = streams_operator_init(lcoreMaster, lcore, nicPort, nicQueue, (int)promiscuous, &dpdkCallback, (void *)this);

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -106,6 +106,8 @@ MY_OPERATOR::MY_OPERATOR() {
   byteCounter = byteCounterNow = byteCounterThen = 0;
   now = then = 0;
   metricsUpdate = false;
+  packetDropSW = packetDropSWNow = packetDropSWThen = 0;
+  maxQueueDepthSW = maxQueueDepthSWNow = maxQueueDepthSWThen = 0;
 #ifdef __ATOMIC_RELAXED
   __atomic_store_n(&realMetricsUpdate, false, __ATOMIC_RELEASE);
 #else
@@ -322,10 +324,13 @@ void MY_OPERATOR::metricsThread() {
     Metric* totalPacketsProcessed = &opm.getCustomMetricByName("nPacketsProcessedCurrent");
     Metric* totalBytesProcessed = &opm.getCustomMetricByName("nBytesProcessedCurrent");
 
+    Metric* totalPacketsDroppedSW = &opm.getCustomMetricByName("nPacketsDroppedSWCurrent");
+    Metric* maxQueueDepthSW = &opm.getCustomMetricByName("maxQueueDepthSWCurrent");
+
     // get statistics periodically and send them to the runtime
     while (!getPE().getShutdownRequested()) {
 
-    // wait until the next interval or the PE is shutting down
+      // wait until the next interval or the PE is shutting down
       const double secondsToWait = now + metricsInterval - SPL::Functions::Time::getTimestampInSecs();
       if (secondsToWait>0) {
         SPLAPPTRC(L_DEBUG, "next statistics interval in " << streams_boost::lexical_cast<std::string>(secondsToWait) << " seconds", "DNSPacketLiveSource");
@@ -341,6 +346,8 @@ void MY_OPERATOR::metricsThread() {
       statsThen.received = statsNow.received; // Packets RX
       statsThen.dropped  = statsNow.dropped;  // All errors and drops
       statsThen.bytes    = statsNow.bytes;    // Bytes RX
+      packetDropSWThen = packetDropSWNow;
+      maxQueueDepthSWThen  = maxQueueDepthSWNow;
 
       // get the current interval's counters from the DPDK library
       now = SPL::Functions::Time::getTimestampInSecs();
@@ -348,12 +355,18 @@ void MY_OPERATOR::metricsThread() {
       packetCounterNow = packetCounter;
       byteCounterNow = byteCounter;
 
+      packetDropSWNow = countDroppedQueueFull;
+      maxQueueDepthSWNow = queueHighWaterMark;
+      queueHighWaterMark = 0;
+
       // expose the operator's statistics as metrics
       totalPacketsReceived->setValue(statsNow.received);
       totalPacketsDropped->setValue(statsNow.dropped);
       totalBytesReceived->setValue(statsNow.bytes);
       totalPacketsProcessed->setValue(packetCounter);
       totalBytesProcessed->setValue(byteCounter);
+      totalPacketsDroppedSW->setValue(packetDropSWNow);
+      maxQueueDepthSW->setValue(maxQueueDepthSWNow);
 
       // updated metrics will be available to the next output tuple emitted
 #ifdef __ATOMIC_RELAXED
@@ -453,22 +466,6 @@ void MY_OPERATOR::processSubmitLoop() {
 
         bool dumpMetrics = false;
         INST_BUCKETS_HANDLE(instBuckets, ts_B, "processSubmitLoop", nicQueue, dumpMetrics);
-
-        if(dumpMetrics) {
-            // The full interval cycle has finished.
-            // In addition to the metrics already dumped above, we should dump the high water mark & the producer drop counts.
-            // Those will all get reset, too.
-
-            struct timespec ts_real;
-            clock_gettime(CLOCK_REALTIME, &ts_real);
-
-            uint64_t lDroppedTooBig = countDroppedTooBig.exchange(0, std::memory_order_relaxed);
-            uint64_t lDroppedQueueFull = countDroppedQueueFull.exchange(0, std::memory_order_relaxed);
-            uint64_t lHighWaterMark = queueHighWaterMark;
-            queueHighWaterMark = 0;
-
-            printf("processSubmitLoop: LONGMETRICS %lu %lu.%09lu : %lu %lu %lu\n", (uint64_t)nicQueue, ts_real.tv_sec, ts_real.tv_nsec, lHighWaterMark, lDroppedTooBig, lDroppedQueueFull);
-        }
     }
 
     SPLAPPTRC(L_TRACE, "leaving <%=$myOperatorKind%> processSubmitLoop()", "PacketDPDKSource");

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -85,7 +85,14 @@ SPL::CodeGen::exit(NetworkResources::NETWORK_TOO_MANY_OUTPUT_FILTERS()) if scala
 static void dpdkCallback(void *correlator, void *data, 
 	                 uint32_t length, uint64_t tscTimestamp) {
     MY_OPERATOR* self = (MY_OPERATOR*)correlator;
-    self->packetProcess((uint8_t *)data, length, tscTimestamp);
+    self->packetEnqueue((uint8_t *)data, length, tscTimestamp);
+}
+
+// Function called on the other side of the circular buffer
+static void submitCallback(void *correlator, void *data, 
+	                 uint32_t length) {
+    MY_OPERATOR* self = (MY_OPERATOR*)correlator;
+    self->packetProcess((uint8_t *)data, length, 0);
 }
 
 MY_OPERATOR::MY_OPERATOR() {
@@ -125,6 +132,11 @@ MY_OPERATOR::MY_OPERATOR() {
   rateLimit = <%=$rateLimit%>;
   rateLimitLastTime = 0;
   rateLimitPeriodUsec = (uint64_t)((1.0 / rateLimit) * 1000000.0);
+
+  countDroppedTooBig = 0;
+  countDroppedQueueFull = 0;
+  queueHighWaterMark = 0;
+  INST_BUCKETS_CLEAR(instBuckets);
 
   // Initialize the DPDK subsystem.
   int rc = streams_operator_init(lcoreMaster, lcore, nicPort, nicQueue, (int)promiscuous, &dpdkCallback, (void *)this);
@@ -174,7 +186,7 @@ void MY_OPERATOR::allPortsReady() {
     tscMicrosecondAdjust = (tscHz + 500000ul) / 1000000ul; 
 
     // create operator threads
-    createThreads(2);
+    createThreads(3);
 
     SPLAPPTRC(L_TRACE, "leaving <%=$myOperatorKind%> allPortsReady()", "PacketDPDKSource");
 }
@@ -196,6 +208,7 @@ void MY_OPERATOR::process(uint32_t idx) {
   switch (idx) {
   case 0: processDpdkLoop(); break;
   case 1: if(metricsInterval > 0) metricsThread(); break;
+  case 2: processSubmitLoop(); break;
   default: break; 
   } 
 
@@ -365,6 +378,67 @@ void MY_OPERATOR::processDpdkLoop() {
 
     SPLAPPTRC(L_TRACE, "leaving <%=$myOperatorKind%> processDpdkLoop()", "PacketDPDKSource");
 }
+
+void MY_OPERATOR::packetEnqueue(uint8_t *packet, uint32_t packetLen, uint64_t tscTimestamp) {
+    // Simply enqueue the packet onto the ring buffer!
+    if(packetLen > PacketRingBuffer::MAX_DATA) {
+        ++countDroppedTooBig;
+    } else if(!pktQueue.produce(packet, packetLen)) {
+        ++countDroppedQueueFull;
+    }
+}
+
+void MY_OPERATOR::processSubmitLoop() {
+    SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> processSubmitLoop()", "PacketDPDKSource");
+
+    bool shutdown = getPE().getShutdownRequested();
+    INST_TS(instBuckets_startTime);
+    while(!shutdown) {
+        // In here, try to consume from the ring buffer
+        // If we consumed a packet, try for another one
+        // Otherwise, check if shutdown is requested (when really busy, don't bother checking for shutdown
+
+        uint64_t ts_A, ts_B;
+        INST_TS(ts_A);
+
+        size_t queueSizeSnapshot = pktQueue.size();
+        if(queueSizeSnapshot > queueHighWaterMark) {
+            queueHighWaterMark = queueSizeSnapshot;
+        }
+
+        if(pktQueue.consume(&submitCallback, this)) {
+            // Got & processed a packet!
+            INST_TS(ts_B);
+            INST_UPDATE_METRIC(instBuckets, 0, ts_B - ts_A);
+        } else {
+            // No packet.
+
+            // Update shutdown flag, since we're apparently not doing anything else.
+            shutdown = getPE().getShutdownRequested();
+
+            INST_TS(ts_B);
+            INST_UPDATE_METRIC(instBuckets, 1, ts_B - ts_A);
+        }
+
+        bool dumpMetrics = false;
+        INST_BUCKETS_HANDLE(instBuckets, ts_B, "processSubmitLoop", nicQueue, dumpMetrics);
+
+        if(dumpMetrics) {
+            // The full interval cycle has finished.
+            // In addition to the metrics already dumped above, we should dump the high water mark & the producer drop counts.
+            // Those will all get reset, too.
+            uint64_t lDroppedTooBig = countDroppedTooBig.exchange(0, std::memory_order_relaxed);
+            uint64_t lDroppedQueueFull = countDroppedQueueFull.exchange(0, std::memory_order_relaxed);
+            uint64_t lHighWaterMark = queueHighWaterMark;
+            queueHighWaterMark = 0;
+
+            printf("processSubmitLoop: LONGMETRICS %lu : %lu %lu %lu\n", (uint64_t)nicQueue, lHighWaterMark, lDroppedTooBig, lDroppedQueueFull);
+        }
+    }
+
+    SPLAPPTRC(L_TRACE, "leaving <%=$myOperatorKind%> processSubmitLoop()", "PacketDPDKSource");
+}
+
 
 <%SPL::CodeGen::implementationEpilogue($model);%>
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -36,6 +36,7 @@ my @outputPortList = @{ $model->getOutputPorts() };
 
 my $lcoreMaster = $model->getParameterByName("lcoreMaster") ? $model->getParameterByName("lcoreMaster")->getValueAt(0)->getCppExpression() : -1;
 my $lcore = $model->getParameterByName("lcore") ? $model->getParameterByName("lcore")->getValueAt(0)->getCppExpression() : 0;
+my $dequeueThreadPinning = $model->getParameterByName("dequeueThreadPinning") ? $model->getParameterByName("dequeueThreadPinning")->getValueAt(0)->getCppExpression() : undef;
 my $nicPort = $model->getParameterByName("nicPort") ? $model->getParameterByName("nicPort")->getValueAt(0)->getCppExpression() : 0;
 my $nicQueue = $model->getParameterByName("nicQueue") ? $model->getParameterByName("nicQueue")->getValueAt(0)->getCppExpression() : 0;
 my $buffersizes = $model->getParameterByName("buffersizes") ? $model->getParameterByName("buffersizes")->getValueAt(0)->getCppExpression() : '""';
@@ -391,6 +392,33 @@ void MY_OPERATOR::packetEnqueue(uint8_t *packet, uint32_t packetLen, uint64_t ts
 void MY_OPERATOR::processSubmitLoop() {
     SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> processSubmitLoop()", "PacketDPDKSource");
 
+    int rc;
+
+<% if(defined $dequeueThreadPinning) { %>
+    // Pin ourselves, if requested
+    std::vector<uint64_t> a = <%=$dequeueThreadPinning%>;
+    cpu_set_t cpumask; // CPU affinity bit mask
+    CPU_ZERO(&cpumask);
+    for (std::vector<uint64_t>::iterator it = a.begin(); it != a.end(); ++it) {
+        CPU_SET(*it, &cpumask);
+    }
+    pid_t mytid = (pid_t)syscall(SYS_gettid);
+    rc = sched_setaffinity(mytid, sizeof cpumask, &cpumask);
+    if (rc<0) THROW (SPLRuntimeOperator, "could not set processor affinity to CPUs" << ", " << strerror(errno));
+<% } %>
+
+    // Name this thread something sensible.
+    // If on the same thread as some downstream SPL code that re-names on first tuple,
+    // that will override, of course.
+    SPL::rstring temp("ring-deq-");
+    temp += std::to_string(nicQueue);
+    if(temp.length() > 15) {
+        temp = temp.substr(0, 15);
+    }
+
+    rc = pthread_setname_np(pthread_self(), temp.c_str());
+    if(rc != 0) THROW (SPLRuntimeOperator, "could not set thread name to " << temp << ", " << strerror(rc));
+
     bool shutdown = getPE().getShutdownRequested();
 
     INST_TS(instBuckets_startTime);
@@ -429,12 +457,16 @@ void MY_OPERATOR::processSubmitLoop() {
             // The full interval cycle has finished.
             // In addition to the metrics already dumped above, we should dump the high water mark & the producer drop counts.
             // Those will all get reset, too.
+
+            struct timespec ts_real;
+            clock_gettime(CLOCK_REALTIME, &ts_real);
+
             uint64_t lDroppedTooBig = countDroppedTooBig.exchange(0, std::memory_order_relaxed);
             uint64_t lDroppedQueueFull = countDroppedQueueFull.exchange(0, std::memory_order_relaxed);
             uint64_t lHighWaterMark = queueHighWaterMark;
             queueHighWaterMark = 0;
 
-            printf("processSubmitLoop: LONGMETRICS %lu : %lu %lu %lu\n", (uint64_t)nicQueue, lHighWaterMark, lDroppedTooBig, lDroppedQueueFull);
+            printf("processSubmitLoop: LONGMETRICS %lu %lu.%09lu : %lu %lu %lu\n", (uint64_t)nicQueue, ts_real.tv_sec, ts_real.tv_nsec, lHighWaterMark, lDroppedTooBig, lDroppedQueueFull);
         }
     }
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -382,9 +382,10 @@ void MY_OPERATOR::processDpdkLoop() {
 
 void MY_OPERATOR::packetEnqueue(uint8_t *packet, uint32_t packetLen, uint64_t tscTimestamp) {
     // Simply enqueue the packet onto the ring buffer!
-    if(packetLen > PacketRingBuffer::MAX_DATA) {
-        ++countDroppedTooBig;
-    } else if(!pktQueue.produce(packet, packetLen)) {
+//    if(packetLen > PacketRingBuffer::MAX_DATA) {
+//        ++countDroppedTooBig;
+//    } else
+    if(!pktQueue.produce(packet, packetLen)) {
         ++countDroppedQueueFull;
     }
 }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -231,8 +231,8 @@ void MY_OPERATOR::packetProcess(uint8_t *packet, uint32_t length, uint64_t tscTi
 
     // Start a prefetch of the packet data.  This was found to help
     // in some situations, but results will vary.
-    __builtin_prefetch((void *)packet, 0, 0);
-    __builtin_prefetch((void *)((uint64_t)packet + packetLen), 0, 0);
+//    __builtin_prefetch((void *)packet, 0, 0);
+//    __builtin_prefetch((void *)((uint64_t)packet + packetLen), 0, 0);
 
   // get current time in microseconds
   struct timespec ts; 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -136,9 +136,8 @@ MY_OPERATOR::MY_OPERATOR() {
   rateLimitLastTime = 0;
   rateLimitPeriodUsec = (uint64_t)((1.0 / rateLimit) * 1000000.0);
 
-  countDroppedTooBig = 0;
-  countDroppedQueueFull = 0;
-  queueHighWaterMark = 0;
+  countDroppedQueueFull.store(0, std::memory_order_release);
+  queueHighWaterMark.store(0, std::memory_order_release);
   INST_BUCKETS_CLEAR(instBuckets);
 
   // Initialize the DPDK subsystem.
@@ -341,6 +340,7 @@ void MY_OPERATOR::metricsThread() {
 
       // store the previous interval's metrics for difference calculations
       then = now;
+      now = SPL::Functions::Time::getTimestampInSecs();
       packetCounterThen = packetCounterNow;
       byteCounterThen = byteCounterNow;
       statsThen.received = statsNow.received; // Packets RX
@@ -349,15 +349,15 @@ void MY_OPERATOR::metricsThread() {
       packetDropSWThen = packetDropSWNow;
       maxQueueDepthSWThen  = maxQueueDepthSWNow;
 
-      // get the current interval's counters from the DPDK library
-      now = SPL::Functions::Time::getTimestampInSecs();
-      streams_port_stats(nicPort, &statsNow);
+      // get the current interval's counters from the DPDK library (only if we're the first queue, to avoid everybody getting the whole-nic metrics and resetting them)
+      if(nicQueue == 0) {
+          streams_port_stats(nicPort, &statsNow);
+      }
       packetCounterNow = packetCounter;
       byteCounterNow = byteCounter;
 
-      packetDropSWNow = countDroppedQueueFull;
-      maxQueueDepthSWNow = queueHighWaterMark;
-      queueHighWaterMark = 0;
+      packetDropSWNow = countDroppedQueueFull.load(std::memory_order_relaxed);
+      maxQueueDepthSWNow = queueHighWaterMark.exchange(0, std::memory_order_acq_rel);
 
       // expose the operator's statistics as metrics
       totalPacketsReceived->setValue(statsNow.received);
@@ -395,9 +395,6 @@ void MY_OPERATOR::processDpdkLoop() {
 
 void MY_OPERATOR::packetEnqueue(uint8_t *packet, uint32_t packetLen, uint64_t tscTimestamp) {
     // Simply enqueue the packet onto the ring buffer!
-//    if(packetLen > PacketRingBuffer::MAX_DATA) {
-//        ++countDroppedTooBig;
-//    } else
     if(!pktQueue.produce(packet, packetLen)) {
         ++countDroppedQueueFull;
     }
@@ -445,10 +442,11 @@ void MY_OPERATOR::processSubmitLoop() {
         uint64_t ts_A, ts_B;
         INST_TS(ts_A);
 
+        // Update the HWM safely, if needed.
+        // The metrics thread might be resetting this value while we are reading here.
         size_t queueSizeSnapshot = pktQueue.size();
-        if(queueSizeSnapshot > queueHighWaterMark) {
-            queueHighWaterMark = queueSizeSnapshot;
-        }
+        size_t oldHWM = queueHighWaterMark.load(std::memory_order_acquire);
+        while(queueSizeSnapshot > oldHWM && !queueHighWaterMark.compare_exchange_weak(oldHWM, queueSizeSnapshot, std::memory_order_acq_rel, std::memory_order_acquire));
 
         if(pktQueue.consume(&submitCallback, this)) {
             // Got & processed a packet!

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_cpp.cgt
@@ -92,12 +92,23 @@ MY_OPERATOR::MY_OPERATOR() {
 
   SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> constructor", "PacketDPDKSource");
 
-  // initialize state variables
-  now = then = 0;
+  // initialize operator state variables
+  dpdkThreadID = metricsThreadID = 0;
   packetCounter = packetCounterNow = packetCounterThen = 0;
   byteCounter = byteCounterNow = byteCounterThen = 0;
-  portStatisticsNow = portStatisticsThen = (const struct port_stats){0};
+  now = then = 0;
   metricsUpdate = false;
+#ifdef __ATOMIC_RELAXED
+  __atomic_store_n(&realMetricsUpdate, false, __ATOMIC_RELEASE);
+#else
+  #pragma message "Using old sync builtins, with GCC " __VERSION__
+  // __sync_synchronize();  // Unnecessary here, in startup, as we're not yet protecting anything from any other threads.  Leaving as reminder that this variable is an atomic.
+     realMetricsUpdate = false;
+  #endif
+
+  // initialize state variables
+  // TODO: this init is not in the DNSPacketDPDKSource, probably need to add?
+  statsNow = statsThen = (const struct port_stats){0};
 
   // Get the operator's parameters into variables.
   lcoreMaster = <%=$lcoreMaster%>;
@@ -240,17 +251,42 @@ void MY_OPERATOR::packetProcess(uint8_t *packet, uint32_t length, uint64_t tscTi
 	return; 
     }
 
+  // Determine if the metrics were updated prior to this packet.
+  // Update the "local" version of the metrics updated flag, so that all output filters/assignments reference a stable copy.
+  /// @todo Under extremely low packet rates, or very short metrics update intervals, it's possible that the previous
+  // metrics copy hasn't yet been consumed when a new one comes in, causing either a total loss of a metrics update,
+  // or, if it lines up just right with an incoming packet, a metrics update with "odd" or part old/part new values.
+  // This should be very uncommon, and not catastrophic, so we are not attempted to protect against this just yet.
+  // This could be addressed at some future time.
+
+#ifdef __ATOMIC_RELAXED
+  bool expected = true;
+  if(__atomic_compare_exchange_n(&realMetricsUpdate, &expected, false, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+      metricsUpdate = true;
+  } else {
+      metricsUpdate = false;
+  }
+#else
+  if(__sync_bool_compare_and_swap(&realMetricsUpdate, true, false)) {
+      metricsUpdate = true;
+  } else {
+      metricsUpdate = false;
+  }
+#endif
+
     // Fill in and submit output tuples to output ports, as selected by output filters, if specified.
     <% for (my $i=0; $i<$model->getNumberOfOutputPorts(); $i++) { %> ;
       <% if (scalar($outputFilterList[$i])) { print "if ($outputFilterList[$i])"; } %> 
       {
          <% CodeGenX::assignOutputAttributeValues("outTuple$i", $model->getOutputPortAt($i)); %> ;
-         SPLAPPTRC(L_TRACE, "submitting outTuple<%=$i%>=" << outTuple<%=$i%>, "PacketDPDKSource");
+         //SPLAPPTRC(L_TRACE, "submitting outTuple<%=$i%>=" << outTuple<%=$i%>, "PacketDPDKSource");
          submit(outTuple<%=$i%>, <%=$i%>);
       }
     <% } %> ;
 
-    // reset the 'metrics updated' flag, in case one of the output filters or assignments references it
+    // reset the "local" version of the 'metrics updated' flag, in case one of the output filters or assignments references it
+    // The "real" version of the flag, as updated by the metricsThread() is unaffected, so we don't lose metrics updates under high-packet-rate
+    // conditions.
     metricsUpdate = false;
 }
 
@@ -259,52 +295,65 @@ void MY_OPERATOR::process(Punctuation const & punct, uint32_t port) {
 } 
 
 void MY_OPERATOR::metricsThread() {
-    SPLAPPTRC(L_TRACE, "entering <%=$myOperatorKind%> metricsThread()", "PacketDPDKSource");
+    SPLAPPTRC(L_DEBUG, "entering <%=$myOperatorKind%> metricsThread()", "DNSPacketDPDKSource");
+
+    // remember our thread identifer
+    metricsThreadID = pthread_self();
 
     // expose the operator's statistics in these metrics
     OperatorMetrics& opm = getContext().getMetrics();
     Metric* totalPacketsReceived = &opm.getCustomMetricByName("nPacketsReceivedCurrent");
     Metric* totalPacketsDropped = &opm.getCustomMetricByName("nPacketsDroppedCurrent");
+    Metric* totalBytesReceived = &opm.getCustomMetricByName("nBytesReceivedCurrent");
     Metric* totalPacketsProcessed = &opm.getCustomMetricByName("nPacketsProcessedCurrent");
     Metric* totalBytesProcessed = &opm.getCustomMetricByName("nBytesProcessedCurrent");
 
     // get statistics periodically and send them to the runtime
     while (!getPE().getShutdownRequested()) {
 
-      // wait until the next interval or the PE is shutting down
+    // wait until the next interval or the PE is shutting down
       const double secondsToWait = now + metricsInterval - SPL::Functions::Time::getTimestampInSecs();
       if (secondsToWait>0) {
-        SPLAPPTRC(L_DEBUG, "next statistics interval in " << streams_boost::lexical_cast<std::string>(secondsToWait) << " seconds", "PacketDPDKSource");
+        SPLAPPTRC(L_DEBUG, "next statistics interval in " << streams_boost::lexical_cast<std::string>(secondsToWait) << " seconds", "DNSPacketLiveSource");
         getPE().blockUntilShutdownRequest(secondsToWait);
       } else {
-        SPLAPPTRC(L_DEBUG, "missed statistics interval by " << streams_boost::lexical_cast<std::string>(-secondsToWait) << " seconds", "PacketDPDKSource");
+        SPLAPPTRC(L_DEBUG, "missed statistics interval by " << streams_boost::lexical_cast<std::string>(-secondsToWait) << " seconds", "DNSPacketLiveSource");
       }
 
       // store the previous interval's metrics for difference calculations
       then = now;
       packetCounterThen = packetCounterNow;
       byteCounterThen = byteCounterNow;
-      portStatisticsThen.received = portStatisticsNow.received;
-      portStatisticsThen.dropped = portStatisticsNow.dropped;
+      statsThen.received = statsNow.received; // Packets RX
+      statsThen.dropped  = statsNow.dropped;  // All errors and drops
+      statsThen.bytes    = statsNow.bytes;    // Bytes RX
 
-      // get the current interval's counters from DPDK
+      // get the current interval's counters from the DPDK library
       now = SPL::Functions::Time::getTimestampInSecs();
-      streams_port_stats(nicPort, &portStatisticsNow);
+      streams_port_stats(nicPort, &statsNow);
       packetCounterNow = packetCounter;
       byteCounterNow = byteCounter;
 
       // expose the operator's statistics as metrics
-      totalPacketsReceived->setValue(portStatisticsNow.received);
-      totalPacketsDropped->setValue(portStatisticsNow.dropped); 
+      totalPacketsReceived->setValue(statsNow.received);
+      totalPacketsDropped->setValue(statsNow.dropped);
+      totalBytesReceived->setValue(statsNow.bytes);
       totalPacketsProcessed->setValue(packetCounter);
       totalBytesProcessed->setValue(byteCounter);
 
       // updated metrics will be available to the next output tuple emitted
-      metricsUpdate = true;
+#ifdef __ATOMIC_RELAXED
+      __atomic_store_n(&realMetricsUpdate, true, __ATOMIC_RELEASE);
+#else
+      __sync_synchronize();
+      realMetricsUpdate = true;
+#endif
+
     }
 
-    SPLAPPTRC(L_TRACE, "leaving <%=$myOperatorKind%> metricsThread()", "PacketDPDKSource");
+    SPLAPPTRC(L_DEBUG, "leaving <%=$myOperatorKind%> metricsThread()", "DNSPacketDPDKSource");
 }
+
 
 void MY_OPERATOR::processDpdkLoop() {
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -148,6 +148,8 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         double now, then;
         bool metricsUpdate;
         bool realMetricsUpdate;
+        uint64_t packetDropSW, packetDropSWNow, packetDropSWThen;
+        uint64_t maxQueueDepthSW, maxQueueDepthSWNow, maxQueueDepthSWThen;
 
         double    rateLimit;
         uint64_t  rateLimitLastTime;
@@ -225,6 +227,15 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
 
   inline __attribute__((always_inline))
   SPL::boolean metricsUpdated() { return then && metricsUpdate; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 packetsDroppedSW() { return packetDropSWNow; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsDroppedSW() { return then ? packetDropSWNow - packetDropSWThen : 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalMaxQueueDepthSW() { return maxQueueDepthSWNow; }
 
   inline __attribute__((always_inline))
 	SPL::uint32 CAPTURE_SECONDS() { return captureSeconds; }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -66,6 +66,53 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         void packetProcess(uint8_t *packet, uint32_t packetLen, uint64_t tscTimestamp);
 
     private:
+  struct DNSResourceRecord {
+    uint8_t name[0];
+    uint16_t type;
+    uint16_t classs;
+    uint32_t ttl;
+    uint16_t rdlength;
+    uint8_t rdata[0];
+  } __attribute__((packed)) ;
+
+  struct DNSHeader {
+    uint16_t identifier;
+    union {
+      struct {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+        uint8_t recursionDesiredFlag:1;
+        uint8_t truncatedFlag:1;
+        uint8_t authoritativeFlag:1;
+        uint8_t opcodeField:4;
+        uint8_t responseFlag:1;
+        uint8_t responseCode:4;
+        uint8_t nonauthenticatedFlag:1;
+        uint8_t authenticatedFlag:1;
+        uint8_t reserved:1;
+        uint8_t recursionAvailableFlag:1;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+        uint8_t responseFlag:1;
+        uint8_t opcodeField:4;
+        uint8_t authoritativeFlag:1;
+        uint8_t truncatedFlag:1;
+        uint8_t recursionDesiredFlag:1;
+        uint8_t recursionAvailableFlag:1;
+        uint8_t reserved:1;
+        uint8_t authenticatedFlag:1;
+        uint8_t nonauthenticatedFlag:1;
+        uint8_t responseCode:4;
+#else
+# error "sorry, __BYTE_ORDER not setm check <bits/endian.h>"
+#endif
+      } indFlags;
+      uint16_t allFlags;
+    } flags;
+    uint16_t questionCount;
+    uint16_t answerCount;
+    uint16_t nameserverCount;
+    uint16_t additionalCount;
+    struct DNSResourceRecord rrFields[0]; // see 'struct DNSResourceRecord'
+  } __attribute__((packed)) ;
 
         // ----------- operator parameters (constant after constructor executes) ----------
 
@@ -277,6 +324,19 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
     }
     return true;
   }
+
+  inline __attribute__((always_inline))
+	SPL::boolean DNS_RESPONSE_FLAG_HINT() { 
+        if(headers.udpHeader == NULL) return false;
+        if(ntohs(headers.udpHeader->source)!=53 && ntohs(headers.udpHeader->dest)!=53) return false;
+        if(!headers.payload) return false; 
+        if(headers.payloadLength < sizeof(struct DNSHeader)) return false; 
+
+        struct DNSHeader* dnsHeader = (struct DNSHeader*)(headers.payload);
+
+        return (dnsHeader->flags.indFlags.responseFlag);
+    }
+
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -36,6 +36,9 @@
 
 #include "parse/NetworkHeaderParser.h"
 
+#include "PacketRingBuffer.h"
+#include "Instrumentation.h"
+
 <%SPL::CodeGen::headerPrologue($model);%>
 
 class MY_OPERATOR : public MY_BASE_OPERATOR {
@@ -61,10 +64,13 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         // Punctuation processing
         void process(Punctuation const & punct, uint32_t port);
 
-        // Method called out of the DPDK callback interface as each packet
+        // Method called out of the ring buffer callback interface as each packet
         // arrives for processing.
         void packetProcess(uint8_t *packet, uint32_t packetLen, uint64_t tscTimestamp);
 
+        // Method called from the DPDK callback interface as each packet arrives
+        void packetEnqueue(uint8_t *packet, uint32_t packetLen, uint64_t tscTimestamp);
+   
     private:
   struct DNSResourceRecord {
     uint8_t name[0];
@@ -150,6 +156,16 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         uint8_t *packetPtr;
         uint32_t packetLen; 
 
+        PacketRingBuffer pktQueue;
+
+        // Counters and stats used by the queue production side
+        std::atomic<uint64_t> countDroppedTooBig;
+        std::atomic<uint64_t> countDroppedQueueFull;
+
+        // Counters and stats used by the queue consumption side
+        uint64_t queueHighWaterMark;
+        INST_BUCKETS_DEFINE(instBuckets);
+
         // This method is called during the start up of the first of the 
         // operator's threads.  It calls into the DPDK libraries, where 
         // the thread spins waiting for packets to arrive.  As each packet 
@@ -161,6 +177,13 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         // operator's threads.  It sits in a loop pulling stats from 
         // the DPDK libraries.
         void metricsThread();
+
+        // This method is called during the startup of the third of the
+        // operator's threads.  It sits in a loop pulling packets off the
+        // internal ring buffer, then parses, filters, and generates tuples
+        // from that data, and submits them downstream.
+        void processSubmitLoop();
+
 
 	// ----------- network header parser ----------
 	NetworkHeaderParser headers;

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -80,15 +80,21 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         <% for (my $i=0; $i<$model->getNumberOfOutputPorts(); $i++) { print "OPort$i\Type outTuple$i;"; } %> ;
       
         // ----------- operator state variables ----------
-
-        double now, then;
-        uint64_t packetCounter, packetCounterNow, packetCounterThen;
-        uint64_t byteCounter, byteCounterNow, byteCounterThen;
-        bool metricsUpdate;
-        struct port_stats portStatisticsNow, portStatisticsThen; 
+        pthread_t dpdkThreadID;
+        pthread_t metricsThreadID;
 
         uint32_t captureSeconds, captureMicroseconds;
         uint64_t tscHz, tscMicrosecondAdjust, tscMicroseconds;
+
+        // Variables related to metrics capture.
+        uint64_t packetCounter;
+        uint64_t byteCounter;
+        uint64_t packetCounterNow, packetCounterThen;
+        uint64_t byteCounterNow, byteCounterThen;
+        struct port_stats statsNow, statsThen;
+        double now, then;
+        bool metricsUpdate;
+        bool realMetricsUpdate;
 
         double    rateLimit;
         uint64_t  rateLimitLastTime;
@@ -114,35 +120,41 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
 	
 	// ----------- assignment functions for output attributes ----------
 
-    inline __attribute__((always_inline))
-	uint64_t packetsReceived() { return portStatisticsNow.received; }
+  inline __attribute__((always_inline))
+  SPL::uint64 packetsReceived() { return statsNow.received; }
 
-    inline __attribute__((always_inline))
-    uint64_t packetsDropped() { return portStatisticsNow.dropped; }
-    
-    inline __attribute__((always_inline))
-    uint64_t packetsProcessed() { return packetCounter; }
-    
-    inline __attribute__((always_inline))
-    uint64_t bytesProcessed() { return byteCounter; }
-    
-    inline __attribute__((always_inline))
-    SPL::float64 metricsIntervalElapsed() { return then ? now-then : 0; }
-    
-    inline __attribute__((always_inline))
-    SPL::uint64 metricsIntervalPacketsReceived() { return then ? portStatisticsNow.received - portStatisticsThen.received : 0; }
-    
-    inline __attribute__((always_inline))
-    SPL::uint64 metricsIntervalPacketsDropped() { return then ? portStatisticsNow.dropped - portStatisticsThen.dropped : 0; }
-    
-    inline __attribute__((always_inline))
-    SPL::uint64 metricsIntervalPacketsProcessed() { return then ? packetCounterNow - packetCounterThen : 0; }
-    
-    inline __attribute__((always_inline))
-    SPL::uint64 metricsIntervalBytesProcessed() { return then ? byteCounterNow - byteCounterThen : 0; }
-    
-    inline __attribute__((always_inline))
-    SPL::boolean metricsUpdated() { return then && metricsUpdate; }
+  inline __attribute__((always_inline))
+  SPL::uint64 packetsDropped() { return statsNow.dropped; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 bytesReceived() { return statsNow.bytes; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 packetsProcessed() { return packetCounter; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 bytesProcessed() { return byteCounter; }
+
+  inline __attribute__((always_inline))
+  SPL::float64 metricsIntervalElapsed() { return then ? now-then : 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsReceived() { return then ? statsNow.received - statsThen.received : 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsDropped() { return then ? statsNow.dropped - statsThen.dropped : 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalBytesReceived() { return then ? statsNow.bytes - statsThen.bytes : 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsProcessed() { return then ? packetCounterNow - packetCounterThen : 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalBytesProcessed() { return then ? byteCounterNow - byteCounterThen : 0; }
+
+  inline __attribute__((always_inline))
+  SPL::boolean metricsUpdated() { return then && metricsUpdate; }
 
   inline __attribute__((always_inline))
 	SPL::uint32 CAPTURE_SECONDS() { return captureSeconds; }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -90,6 +90,10 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         uint32_t captureSeconds, captureMicroseconds;
         uint64_t tscHz, tscMicrosecondAdjust, tscMicroseconds;
 
+        double    rateLimit;
+        uint64_t  rateLimitLastTime;
+        uint64_t  rateLimitPeriodUsec;
+
         uint8_t *packetPtr;
         uint32_t packetLen; 
 
@@ -166,6 +170,9 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
 
   inline __attribute__((always_inline))
 	SPL::list<SPL::uint8> ETHER_DST_ADDRESS() { return headers.etherHeader ? SPL::list<SPL::uint8>(headers.etherHeader->h_dest, headers.etherHeader->h_dest+sizeof(headers.etherHeader->h_dest)) : SPL::list<uint8>(); }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 ETHER_DST_ADDRESS_64() { return headers.etherHeader ? (((uint64_t)headers.etherHeader->h_dest[0] << 40) | ((uint64_t)headers.etherHeader->h_dest[1] << 32) | ((uint64_t)headers.etherHeader->h_dest[2] << 24) | ((uint64_t)headers.etherHeader->h_dest[3] << 16) | ((uint64_t)headers.etherHeader->h_dest[4] << 8) | ((uint64_t)headers.etherHeader->h_dest[5] << 0)) : 0; }
 
   inline __attribute__((always_inline))
 	SPL::uint32 ETHER_PROTOCOL() { return headers.etherHeader ? ntohs(headers.etherHeader->h_proto) : 0; }
@@ -247,6 +254,17 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
 
   inline __attribute__((always_inline))
     SPL::list<uint16> VLAN_TAGS() { return (headers.convertVlanTagsToList()); }  
+
+  inline __attribute__((always_inline))
+  SPL::boolean RATE_LIMITED() {
+    // This gets the recorded time when the last packet came in which is close enough for what we need here.
+    uint64_t currentTime = ((uint64)CAPTURE_SECONDS()*1000000ul)+(uint64)CAPTURE_MICROSECONDS();
+    if(currentTime >= (rateLimitLastTime + rateLimitPeriodUsec)) {
+        rateLimitLastTime = currentTime;
+        return false;
+    }
+    return true;
+  }
 }; 
 
 <%SPL::CodeGen::headerEpilogue($model);%>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -161,11 +161,10 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         PacketRingBuffer pktQueue;
 
         // Counters and stats used by the queue production side
-        std::atomic<uint64_t> countDroppedTooBig __attribute__((aligned(64)));
-        std::atomic<uint64_t> countDroppedQueueFull;
+        std::atomic<uint64_t> countDroppedQueueFull __attribute__((aligned(64)));
 
         // Counters and stats used by the queue consumption side
-        uint64_t queueHighWaterMark __attribute__((aligned(64)));
+        std::atomic<uint64_t> queueHighWaterMark __attribute__((aligned(64)));
         INST_BUCKETS_DEFINE(instBuckets);
 
         // This method is called during the start up of the first of the 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -72,53 +72,6 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         void packetEnqueue(uint8_t *packet, uint32_t packetLen, uint64_t tscTimestamp);
    
     private:
-  struct DNSResourceRecord {
-    uint8_t name[0];
-    uint16_t type;
-    uint16_t classs;
-    uint32_t ttl;
-    uint16_t rdlength;
-    uint8_t rdata[0];
-  } __attribute__((packed)) ;
-
-  struct DNSHeader {
-    uint16_t identifier;
-    union {
-      struct {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-        uint8_t recursionDesiredFlag:1;
-        uint8_t truncatedFlag:1;
-        uint8_t authoritativeFlag:1;
-        uint8_t opcodeField:4;
-        uint8_t responseFlag:1;
-        uint8_t responseCode:4;
-        uint8_t nonauthenticatedFlag:1;
-        uint8_t authenticatedFlag:1;
-        uint8_t reserved:1;
-        uint8_t recursionAvailableFlag:1;
-#elif __BYTE_ORDER == __BIG_ENDIAN
-        uint8_t responseFlag:1;
-        uint8_t opcodeField:4;
-        uint8_t authoritativeFlag:1;
-        uint8_t truncatedFlag:1;
-        uint8_t recursionDesiredFlag:1;
-        uint8_t recursionAvailableFlag:1;
-        uint8_t reserved:1;
-        uint8_t authenticatedFlag:1;
-        uint8_t nonauthenticatedFlag:1;
-        uint8_t responseCode:4;
-#else
-# error "sorry, __BYTE_ORDER not setm check <bits/endian.h>"
-#endif
-      } indFlags;
-      uint16_t allFlags;
-    } flags;
-    uint16_t questionCount;
-    uint16_t answerCount;
-    uint16_t nameserverCount;
-    uint16_t additionalCount;
-    struct DNSResourceRecord rrFields[0]; // see 'struct DNSResourceRecord'
-  } __attribute__((packed)) ;
 
         // ----------- operator parameters (constant after constructor executes) ----------
 
@@ -359,16 +312,23 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
   }
 
   inline __attribute__((always_inline))
-	SPL::boolean DNS_RESPONSE_FLAG_HINT() { 
+  SPL::boolean DNS_RESPONSE_FLAG_HINT() {
+        // Only UDP DNS packets will be analyzed at this time
         if(headers.udpHeader == NULL) return false;
+
+        // 53 is the UDP port used for DNS requests/responses
         if(ntohs(headers.udpHeader->source)!=53 && ntohs(headers.udpHeader->dest)!=53) return false;
-        if(!headers.payload) return false; 
-        if(headers.payloadLength < sizeof(struct DNSHeader)) return false; 
+        if(!headers.payload) return false;
 
-        struct DNSHeader* dnsHeader = (struct DNSHeader*)(headers.payload);
+        // DNS Header is 12 bytes minimum, so anything less than that can be dropped.
+        if(headers.payloadLength < 12) return false;
 
-        return (dnsHeader->flags.indFlags.responseFlag);
-    }
+        uint8_t* payloadBytes = (uint8_t*)(headers.payload);
+
+        // For DNS packets, the MSB of the 3rd byte of the payload is the response flag.
+        // The DNS packet header is in network-order, of course.
+        return (payloadBytes[2] & 0x80);
+  }
 
 }; 
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketDPDKSource/PacketDPDKSource_h.cgt
@@ -159,11 +159,11 @@ class MY_OPERATOR : public MY_BASE_OPERATOR {
         PacketRingBuffer pktQueue;
 
         // Counters and stats used by the queue production side
-        std::atomic<uint64_t> countDroppedTooBig;
+        std::atomic<uint64_t> countDroppedTooBig __attribute__((aligned(64)));
         std::atomic<uint64_t> countDroppedQueueFull;
 
         // Counters and stats used by the queue consumption side
-        uint64_t queueHighWaterMark;
+        uint64_t queueHighWaterMark __attribute__((aligned(64)));
         INST_BUCKETS_DEFINE(instBuckets);
 
         // This method is called during the start up of the first of the 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource.xml
@@ -395,6 +395,26 @@ The default value is '10.0'.
         <type>float64</type>
         <cardinality>1</cardinality>
       </parameter>
+
+    <parameter>
+      <name>rateLimit</name>
+      <description>
+
+This optional parameter takes an expression of type 'float64'
+that specifies the maximum number of times per second the RATE_LIMITED()
+function returns false.  This can be used to limit the rate of packets sent
+to an output port when used in a filter expression.
+
+The default value is '1000.0'.
+
+      </description>
+      <optional>true</optional>
+      <rewriteAllowed>true</rewriteAllowed>
+      <expressionMode>Expression</expressionMode>
+      <type>float64</type>
+      <cardinality>1</cardinality>
+    </parameter>
+
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource_cpp.cgt
@@ -28,6 +28,7 @@ my $initDelay = $model->getParameterByName("initDelay") ? $model->getParameterBy
 my $processorAffinity = $model->getParameterByName("processorAffinity") ? $model->getParameterByName("processorAffinity")->getValueAt(0)->getCppExpression() : -1;
 my $jMirrorCheck = $model->getParameterByName("jMirrorCheck") ? $model->getParameterByName("jMirrorCheck")->getValueAt(0)->getCppExpression() : 0;
 my $metricsInterval = $model->getParameterByName("metricsInterval") ? $model->getParameterByName("metricsInterval")->getValueAt(0)->getCppExpression() : 10.0;
+my $rateLimit = $model->getParameterByName("rateLimit") ? $model->getParameterByName("rateLimit")->getValueAt(0)->getCppExpression() : 1000.0;
 
 # special handling for 'outputFilters' parameter, which may include SPL functions that reference input tuples indirectly
 my $outputFilterParameter = $model->getParameterByName("outputFilters");
@@ -81,6 +82,12 @@ MY_OPERATOR::MY_OPERATOR()
   processorAffinity = <%=$processorAffinity%>;
   jMirrorCheck = <%=$jMirrorCheck%>;
   metricsInterval = <%=$metricsInterval%>;
+
+  // Set up rate limiter parameters.  This approach scales to 1M pps, or 1 per usec and then
+  // goes unlimited. 
+  rateLimit = <%=$rateLimit%>;
+  rateLimitLastTime = 0;
+  rateLimitPeriodUsec = (uint64_t)((1.0 / rateLimit) * 1000000.0);
 
   // initialize operator state variables
   startTimeInNanoseconds = SPL::Functions::Time::getCPUCounterInNanoSeconds();

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource_h.cgt
@@ -62,6 +62,53 @@ public:
   void metricsThread();
 
  private:
+  struct DNSResourceRecord {
+    uint8_t name[0];
+    uint16_t type;
+    uint16_t classs;
+    uint32_t ttl;
+    uint16_t rdlength;
+    uint8_t rdata[0];
+  } __attribute__((packed)) ;
+
+  struct DNSHeader {
+    uint16_t identifier;
+    union {
+      struct {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+        uint8_t recursionDesiredFlag:1;
+        uint8_t truncatedFlag:1;
+        uint8_t authoritativeFlag:1;
+        uint8_t opcodeField:4;
+        uint8_t responseFlag:1;
+        uint8_t responseCode:4;
+        uint8_t nonauthenticatedFlag:1;
+        uint8_t authenticatedFlag:1;
+        uint8_t reserved:1;
+        uint8_t recursionAvailableFlag:1;
+#elif __BYTE_ORDER == __BIG_ENDIAN
+        uint8_t responseFlag:1;
+        uint8_t opcodeField:4;
+        uint8_t authoritativeFlag:1;
+        uint8_t truncatedFlag:1;
+        uint8_t recursionDesiredFlag:1;
+        uint8_t recursionAvailableFlag:1;
+        uint8_t reserved:1;
+        uint8_t authenticatedFlag:1;
+        uint8_t nonauthenticatedFlag:1;
+        uint8_t responseCode:4;
+#else
+# error "sorry, __BYTE_ORDER not setm check <bits/endian.h>"
+#endif
+      } indFlags;
+      uint16_t allFlags;
+    } flags;
+    uint16_t questionCount;
+    uint16_t answerCount;
+    uint16_t nameserverCount;
+    uint16_t additionalCount;
+    struct DNSResourceRecord rrFields[0]; // see 'struct DNSResourceRecord'
+  } __attribute__((packed)) ;
 
   // ----------- operator parameters (constant after constructor executes) ----------
 
@@ -87,6 +134,10 @@ public:
   bool metricsUpdate;
   boolean done;
 
+  double    rateLimit;
+  uint64_t  rateLimitLastTime;
+  uint64_t  rateLimitPeriodUsec;
+
   // ----------- libpcap-specific variables ----------
 
   pcap_t* pcapDescriptor;
@@ -109,6 +160,9 @@ public:
   SPL::uint64 packetsDropped() { return 0; }
 
   inline __attribute__((always_inline))
+  SPL::uint64 bytesReceived() { return byteCounter; }
+
+  inline __attribute__((always_inline))
   SPL::uint64 packetsProcessed() { return packetCounter; }
 
   inline __attribute__((always_inline))
@@ -122,6 +176,9 @@ public:
 
   inline __attribute__((always_inline))
   SPL::uint64 metricsIntervalPacketsDropped() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalBytesReceived() { return then ? byteCounterNow - byteCounterThen : 0; }
 
   inline __attribute__((always_inline))
   SPL::uint64 metricsIntervalPacketsProcessed() { return then ? packetCounterNow - packetCounterThen : 0; }
@@ -155,6 +212,9 @@ public:
 
   inline __attribute__((always_inline))
   SPL::list<SPL::uint8> ETHER_DST_ADDRESS() { return headers.etherHeader ? SPL::list<SPL::uint8>(headers.etherHeader->h_dest, headers.etherHeader->h_dest+sizeof(headers.etherHeader->h_dest)) : SPL::list<uint8>(); }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 ETHER_DST_ADDRESS_64() { return headers.etherHeader ? (((uint64_t)headers.etherHeader->h_dest[0] << 40) | ((uint64_t)headers.etherHeader->h_dest[1] << 32) | ((uint64_t)headers.etherHeader->h_dest[2] << 24) | ((uint64_t)headers.etherHeader->h_dest[3] << 16) | ((uint64_t)headers.etherHeader->h_dest[4] << 8) | ((uint64_t)headers.etherHeader->h_dest[5] << 0)) : 0; }
 
   inline __attribute__((always_inline))
   SPL::uint32 ETHER_PROTOCOL() { return headers.etherHeader ? ntohs(headers.etherHeader->h_proto) : 0; }
@@ -262,6 +322,29 @@ public:
   
   inline __attribute__((always_inline))
   SPL::list<uint16> VLAN_TAGS() { return (headers.convertVlanTagsToList()); }  
+
+inline __attribute__((always_inline))
+  SPL::boolean RATE_LIMITED() {
+    // This gets the recorded time when the last packet came in which is close enough for what we need here.
+    uint64_t currentTime = ((uint64)CAPTURE_SECONDS()*1000000ul)+(uint64)CAPTURE_MICROSECONDS();
+    if(currentTime >= (rateLimitLastTime + rateLimitPeriodUsec)) {
+        rateLimitLastTime = currentTime;
+        return false;
+    }
+    return true;
+  }
+
+  inline __attribute__((always_inline))
+    SPL::boolean DNS_RESPONSE_FLAG_HINT() {
+        if(headers.udpHeader == NULL) return false;
+        if(ntohs(headers.udpHeader->source)!=53 && ntohs(headers.udpHeader->dest)!=53) return false;
+        if(!headers.payload) return false;
+        if(headers.payloadLength < sizeof(struct DNSHeader)) return false;
+
+        struct DNSHeader* dnsHeader = (struct DNSHeader*)(headers.payload);
+
+        return (dnsHeader->flags.indFlags.responseFlag);
+    }
 
   inline __attribute__((always_inline))
   SPL::uint32 ERSPAN_SRC_ADDRESS() { return headers.erspanHeader ? ntohl(headers.erspanHeader->ipHeader.saddr) : 0; }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketFileSource/PacketFileSource_h.cgt
@@ -62,53 +62,6 @@ public:
   void metricsThread();
 
  private:
-  struct DNSResourceRecord {
-    uint8_t name[0];
-    uint16_t type;
-    uint16_t classs;
-    uint32_t ttl;
-    uint16_t rdlength;
-    uint8_t rdata[0];
-  } __attribute__((packed)) ;
-
-  struct DNSHeader {
-    uint16_t identifier;
-    union {
-      struct {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-        uint8_t recursionDesiredFlag:1;
-        uint8_t truncatedFlag:1;
-        uint8_t authoritativeFlag:1;
-        uint8_t opcodeField:4;
-        uint8_t responseFlag:1;
-        uint8_t responseCode:4;
-        uint8_t nonauthenticatedFlag:1;
-        uint8_t authenticatedFlag:1;
-        uint8_t reserved:1;
-        uint8_t recursionAvailableFlag:1;
-#elif __BYTE_ORDER == __BIG_ENDIAN
-        uint8_t responseFlag:1;
-        uint8_t opcodeField:4;
-        uint8_t authoritativeFlag:1;
-        uint8_t truncatedFlag:1;
-        uint8_t recursionDesiredFlag:1;
-        uint8_t recursionAvailableFlag:1;
-        uint8_t reserved:1;
-        uint8_t authenticatedFlag:1;
-        uint8_t nonauthenticatedFlag:1;
-        uint8_t responseCode:4;
-#else
-# error "sorry, __BYTE_ORDER not setm check <bits/endian.h>"
-#endif
-      } indFlags;
-      uint16_t allFlags;
-    } flags;
-    uint16_t questionCount;
-    uint16_t answerCount;
-    uint16_t nameserverCount;
-    uint16_t additionalCount;
-    struct DNSResourceRecord rrFields[0]; // see 'struct DNSResourceRecord'
-  } __attribute__((packed)) ;
 
   // ----------- operator parameters (constant after constructor executes) ----------
 
@@ -160,7 +113,7 @@ public:
   SPL::uint64 packetsDropped() { return 0; }
 
   inline __attribute__((always_inline))
-  SPL::uint64 bytesReceived() { return byteCounter; }
+  SPL::uint64 bytesReceived() { return 0; }
 
   inline __attribute__((always_inline))
   SPL::uint64 packetsProcessed() { return packetCounter; }
@@ -178,7 +131,7 @@ public:
   SPL::uint64 metricsIntervalPacketsDropped() { return 0; }
 
   inline __attribute__((always_inline))
-  SPL::uint64 metricsIntervalBytesReceived() { return then ? byteCounterNow - byteCounterThen : 0; }
+  SPL::uint64 metricsIntervalBytesReceived() { return 0; }
 
   inline __attribute__((always_inline))
   SPL::uint64 metricsIntervalPacketsProcessed() { return then ? packetCounterNow - packetCounterThen : 0; }
@@ -188,6 +141,15 @@ public:
 
   inline __attribute__((always_inline))
   SPL::boolean metricsUpdated() { return then && metricsUpdate; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 packetsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalMaxQueueDepthSW() { return 0; }
 
   inline __attribute__((always_inline))
   SPL::uint32 CAPTURE_SECONDS() { return pcapHeader->ts.tv_sec; }
@@ -323,7 +285,7 @@ public:
   inline __attribute__((always_inline))
   SPL::list<uint16> VLAN_TAGS() { return (headers.convertVlanTagsToList()); }  
 
-inline __attribute__((always_inline))
+  inline __attribute__((always_inline))
   SPL::boolean RATE_LIMITED() {
     // This gets the recorded time when the last packet came in which is close enough for what we need here.
     uint64_t currentTime = ((uint64)CAPTURE_SECONDS()*1000000ul)+(uint64)CAPTURE_MICROSECONDS();
@@ -335,16 +297,23 @@ inline __attribute__((always_inline))
   }
 
   inline __attribute__((always_inline))
-    SPL::boolean DNS_RESPONSE_FLAG_HINT() {
+  SPL::boolean DNS_RESPONSE_FLAG_HINT() {
+        // Only UDP DNS packets will be analyzed at this time
         if(headers.udpHeader == NULL) return false;
+
+        // 53 is the UDP port used for DNS requests/responses
         if(ntohs(headers.udpHeader->source)!=53 && ntohs(headers.udpHeader->dest)!=53) return false;
         if(!headers.payload) return false;
-        if(headers.payloadLength < sizeof(struct DNSHeader)) return false;
 
-        struct DNSHeader* dnsHeader = (struct DNSHeader*)(headers.payload);
+        // DNS Header is 12 bytes minimum, so anything less than that can be dropped.
+        if(headers.payloadLength < 12) return false;
 
-        return (dnsHeader->flags.indFlags.responseFlag);
-    }
+        uint8_t* payloadBytes = (uint8_t*)(headers.payload);
+
+        // For DNS packets, the MSB of the 3rd byte of the payload is the response flag.
+        // The DNS packet header is in network-order, of course.
+        return (payloadBytes[2] & 0x80);
+  }
 
   inline __attribute__((always_inline))
   SPL::uint32 ERSPAN_SRC_ADDRESS() { return headers.erspanHeader ? ntohl(headers.erspanHeader->ipHeader.saddr) : 0; }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketLiveSource/PacketLiveSource.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketLiveSource/PacketLiveSource.xml
@@ -609,6 +609,26 @@ The default value is '10.0'.
         <type>float64</type>
         <cardinality>1</cardinality>
       </parameter>
+
+    <parameter>
+      <name>rateLimit</name>
+      <description>
+
+This optional parameter takes an expression of type 'float64'
+that specifies the maximum number of times per second the RATE_LIMITED()
+function returns false.  This can be used to limit the rate of packets sent
+to an output port when used in a filter expression.
+
+The default value is '1000.0'.
+
+      </description>
+      <optional>true</optional>
+      <rewriteAllowed>true</rewriteAllowed>
+      <expressionMode>Expression</expressionMode>
+      <type>float64</type>
+      <cardinality>1</cardinality>
+    </parameter>
+
     </parameters>
     <inputPorts/>
     <outputPorts>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketLiveSource/PacketLiveSource_cpp.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketLiveSource/PacketLiveSource_cpp.cgt
@@ -32,6 +32,7 @@ my $jMirrorCheck = $model->getParameterByName("jMirrorCheck") ? $model->getParam
 my $timeout = $model->getParameterByName("timeout") ? $model->getParameterByName("timeout")->getValueAt(0)->getCppExpression() : 0;
 my $inputFilter = $model->getParameterByName("inputFilter") ? $model->getParameterByName("inputFilter")->getValueAt(0)->getCppExpression() : undef;
 my $metricsInterval = $model->getParameterByName("metricsInterval") ? $model->getParameterByName("metricsInterval")->getValueAt(0)->getCppExpression() : 10.0;
+my $rateLimit = $model->getParameterByName("rateLimit") ? $model->getParameterByName("rateLimit")->getValueAt(0)->getCppExpression() : 1000.0;
 
 # special handling for 'outputFilters' parameter, which may include SPL functions that reference input tuples indirectly
 my $outputFilterParameter = $model->getParameterByName("outputFilters");
@@ -81,6 +82,12 @@ MY_OPERATOR::MY_OPERATOR()
   timeout = <%=$timeout%>;
   inputFilter = <%= $inputFilter ? $inputFilter : '""' %>;
   metricsInterval = <%=$metricsInterval%>;
+
+  // Set up rate limiter parameters.  This approach scales to 1M pps, or 1 per usec and then
+  // goes unlimited. 
+  rateLimit = <%=$rateLimit%>;
+  rateLimitLastTime = 0;
+  rateLimitPeriodUsec = (uint64_t)((1.0 / rateLimit) * 1000000.0);
 
   // initialize operator state variables
   pcapThreadID = metricsThreadID = 0;

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketLiveSource/PacketLiveSource_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/PacketLiveSource/PacketLiveSource_h.cgt
@@ -82,6 +82,10 @@ private:
   uint64_t byteCounter, byteCounterNow, byteCounterThen;
   bool metricsUpdate;
 
+  double    rateLimit;
+  uint64_t  rateLimitLastTime;
+  uint64_t  rateLimitPeriodUsec;
+
   // ----------- libpcap-specific variables ----------
 
   pcap_t* pcapDescriptor;
@@ -102,6 +106,9 @@ private:
   SPL::uint64 packetsDropped() { return pcapStatisticsNow.ps_drop; }
 
   inline __attribute__((always_inline))
+  SPL::uint64 bytesReceived() { return 0; }
+
+  inline __attribute__((always_inline))
   SPL::uint64 packetsProcessed() { return packetCounter; }
 
   inline __attribute__((always_inline))
@@ -117,6 +124,9 @@ private:
   SPL::uint64 metricsIntervalPacketsDropped() { return then ? pcapStatisticsNow.ps_drop - pcapStatisticsThen.ps_drop : 0; }
 
   inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalBytesReceived() { return 0; }
+
+  inline __attribute__((always_inline))
   SPL::uint64 metricsIntervalPacketsProcessed() { return then ? packetCounterNow - packetCounterThen : 0; }
 
   inline __attribute__((always_inline))
@@ -124,6 +134,15 @@ private:
 
   inline __attribute__((always_inline))
   SPL::boolean metricsUpdated() { return then && metricsUpdate; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 packetsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalPacketsDroppedSW() { return 0; }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 metricsIntervalMaxQueueDepthSW() { return 0; }
 
   inline __attribute__((always_inline))
   SPL::uint32 CAPTURE_SECONDS() { return pcapHeader->ts.tv_sec; }
@@ -148,6 +167,9 @@ private:
 
   inline __attribute__((always_inline))
   SPL::list<SPL::uint8> ETHER_DST_ADDRESS() { return headers.etherHeader ? SPL::list<SPL::uint8>(headers.etherHeader->h_dest, headers.etherHeader->h_dest+sizeof(headers.etherHeader->h_dest)) : SPL::list<uint8>(); }
+
+  inline __attribute__((always_inline))
+  SPL::uint64 ETHER_DST_ADDRESS_64() { return headers.etherHeader ? (((uint64_t)headers.etherHeader->h_dest[0] << 40) | ((uint64_t)headers.etherHeader->h_dest[1] << 32) | ((uint64_t)headers.etherHeader->h_dest[2] << 24) | ((uint64_t)headers.etherHeader->h_dest[3] << 16) | ((uint64_t)headers.etherHeader->h_dest[4] << 8) | ((uint64_t)headers.etherHeader->h_dest[5] << 0)) : 0; }
 
   inline __attribute__((always_inline))
   SPL::uint32 ETHER_PROTOCOL() { return headers.etherHeader ? ntohs(headers.etherHeader->h_proto) : 0; }
@@ -253,6 +275,36 @@ private:
   
   inline __attribute__((always_inline))
   SPL::list<uint16> VLAN_TAGS() { return (headers.convertVlanTagsToList()); }  
+
+  inline __attribute__((always_inline))
+  SPL::boolean RATE_LIMITED() {
+    // This gets the recorded time when the last packet came in which is close enough for what we need here.
+    uint64_t currentTime = ((uint64)CAPTURE_SECONDS()*1000000ul)+(uint64)CAPTURE_MICROSECONDS();
+    if(currentTime >= (rateLimitLastTime + rateLimitPeriodUsec)) {
+        rateLimitLastTime = currentTime;
+        return false;
+    }
+    return true;
+  }
+
+  inline __attribute__((always_inline))
+  SPL::boolean DNS_RESPONSE_FLAG_HINT() {
+        // Only UDP DNS packets will be analyzed at this time
+        if(headers.udpHeader == NULL) return false;
+
+        // 53 is the UDP port used for DNS requests/responses
+        if(ntohs(headers.udpHeader->source)!=53 && ntohs(headers.udpHeader->dest)!=53) return false;
+        if(!headers.payload) return false;
+
+        // DNS Header is 12 bytes minimum, so anything less than that can be dropped.
+        if(headers.payloadLength < 12) return false;
+
+        uint8_t* payloadBytes = (uint8_t*)(headers.payload);
+
+        // For DNS packets, the MSB of the 3rd byte of the payload is the response flag.
+        // The DNS packet header is in network-order, of course.
+        return (payloadBytes[2] & 0x80);
+  }
 
   inline __attribute__((always_inline))
   SPL::uint32 ERSPAN_SRC_ADDRESS() { return headers.erspanHeader ? ntohl(headers.erspanHeader->ipHeader.saddr) : 0; }

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
@@ -642,6 +642,16 @@ if it has one, or zero if otherwise.
             <function:prototype>public boolean RATE_LIMITED()</function:prototype>
           </function:function>
 
+          <function:function>
+            <function:description>
+            This function speculatively returns the DNS response flag.  Full packet parsing with validation
+            is not performed.  Instead, simple basic checks are made and then the response bit is returned.
+            This means that all actual DNS packets that are responses are returned correctly, but some
+            non-DNS packets might also be flagged as a DNS response.
+            </function:description>
+            <function:prototype>public boolean DNS_RESPONSE_FLAG_HINT()</function:prototype>
+          </function:function>
+
     </function:functions>
   </function:functionSet>
 

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
@@ -144,6 +144,33 @@ and returns `false` for all subsequent tuples produced in the same metrics inter
           <function:function>
             <function:description>
 
+This function returns the total number of packets dropped by the software packet receive queue.
+
+            </function:description>
+            <function:prototype>public uint64 packetsDroppedSW()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
+This function returns the number of packets dropped by the software packet receive queue in the most recent metrics interval.
+
+            </function:description>
+            <function:prototype>public uint64 metricsIntervalPacketsDroppedSW()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
+This function returns the software receive queue high water mark from the most recent metrics interval.
+
+            </function:description>
+            <function:prototype>public uint64 metricsIntervalMaxQueueDepthSW()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
 This function returns the number of seconds since the beginning of the Unix epoch
 (midnight on January 1st, 1970 in Greenwich, England) until the current packet was captured,
 according to the system clock on the machine that captured it.

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
@@ -35,7 +35,7 @@ This function always returns zero for the PacketFileSource operator.
 
 This function returns the number of bytes received from the network interface
 since the operator started, as of the most recent metrics interval, if there is one, or zero if not.
-This function always returns zero for the DNSPacketLiveSource and DNSPacketFileSource operators.
+This function always returns zero for the PacketLiveSource and PacketFileSource operators.
 
             </function:description>
             <function:prototype>public uint64 bytesReceived()</function:prototype>
@@ -68,7 +68,7 @@ This function always returns zero for the PacketFileSource operator.
 
 This function returns the number of bytes received from the network interface
 during the most recent metrics interval, if there is one, or zero if not.
-This function always returns zero for the DNSPacketLiveSource and DNSPacketFileSource operators.
+This function always returns zero for the PacketLiveSource and PacketFileSource operators.
 
             </function:description>
             <function:prototype>public uint64 metricsIntervalBytesReceived()</function:prototype>
@@ -144,7 +144,8 @@ and returns `false` for all subsequent tuples produced in the same metrics inter
           <function:function>
             <function:description>
 
-This function returns the total number of packets dropped by the software packet receive queue.
+This function returns the total number of packets dropped by the software packet receive queue (if implemented).
+Otherwise, returns 0.
 
             </function:description>
             <function:prototype>public uint64 packetsDroppedSW()</function:prototype>
@@ -153,7 +154,8 @@ This function returns the total number of packets dropped by the software packet
           <function:function>
             <function:description>
 
-This function returns the number of packets dropped by the software packet receive queue in the most recent metrics interval.
+This function returns the number of packets dropped by the software packet receive queue (if implemented) in the
+most recent metrics interval.  Otherwise, returns 0.
 
             </function:description>
             <function:prototype>public uint64 metricsIntervalPacketsDroppedSW()</function:prototype>
@@ -162,7 +164,8 @@ This function returns the number of packets dropped by the software packet recei
           <function:function>
             <function:description>
 
-This function returns the software receive queue high water mark from the most recent metrics interval.
+This function returns the software receive queue (if implemented) high water mark from the most recent metrics interval.
+Otherwise, returns 0.
 
             </function:description>
             <function:prototype>public uint64 metricsIntervalMaxQueueDepthSW()</function:prototype>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
@@ -222,6 +222,15 @@ This function returns the ethernet destination address of the current packet.
           <function:function>
             <function:description>
 
+This function returns the ethernet destination address of the current packet in the 48 low-order bits of a uint64.
+
+            </function:description>
+            <function:prototype>public uint64 ETHER_DST_ADDRESS_64()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
 This function returns the ethernet protocol (that is, the EtherType) of the
 current packet, for example, '2048' for IP version 4, or '34,525' for IP version 6.
 
@@ -601,6 +610,14 @@ if it has one, or zero if otherwise.
 
             </function:description>
             <function:prototype>public uint32 ERSPAN_DST_ADDRESS()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+            This function returns false when an amount of time between packets has passed such that
+            the rate is limited to the value given in the rateLimit paramater.
+            </function:description>
+            <function:prototype>public boolean RATE_LIMITED()</function:prototype>
           </function:function>
 
     </function:functions>

--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.source/native.function/function.xml
@@ -33,6 +33,17 @@ This function always returns zero for the PacketFileSource operator.
           <function:function>
             <function:description>
 
+This function returns the number of bytes received from the network interface
+since the operator started, as of the most recent metrics interval, if there is one, or zero if not.
+This function always returns zero for the DNSPacketLiveSource and DNSPacketFileSource operators.
+
+            </function:description>
+            <function:prototype>public uint64 bytesReceived()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
 This function returns the number of packets received from the network interface 
 during the most recent metrics interval, if there is one, or zero if not.
 This function always returns zero for the PacketFileSource operator.
@@ -50,6 +61,17 @@ This function always returns zero for the PacketFileSource operator.
 
             </function:description>
             <function:prototype>public uint64 metricsIntervalPacketsDropped()</function:prototype>
+          </function:function>
+
+          <function:function>
+            <function:description>
+
+This function returns the number of bytes received from the network interface
+during the most recent metrics interval, if there is one, or zero if not.
+This function always returns zero for the DNSPacketLiveSource and DNSPacketFileSource operators.
+
+            </function:description>
+            <function:prototype>public uint64 metricsIntervalBytesReceived()</function:prototype>
           </function:function>
 
           <function:function>

--- a/com.ibm.streamsx.network/impl/include/Instrumentation.h
+++ b/com.ibm.streamsx.network/impl/include/Instrumentation.h
@@ -14,7 +14,7 @@
 
 
 
-#define INST_ENABLE
+//#define INST_ENABLE
 
 #define INST_BUCKET_SIZE (60UL * 2194707391UL)
 #define INST_BUCKET_COUNT 10

--- a/com.ibm.streamsx.network/impl/include/Instrumentation.h
+++ b/com.ibm.streamsx.network/impl/include/Instrumentation.h
@@ -22,12 +22,12 @@
 #define INST_METRIC_COUNT 2
 #ifdef INST_ENABLE
 #define INST_TS(d) d = __rdtsc()
-#define INST_UPDATE_METRIC(v, m, d) instAddToMetric(&v[v_index].metrics[m], (d))
-#define INST_SET_BUCKET_START(v, d) v_startTime = d
-#define INST_BUCKETS_DEFINE(v)                  \
-    InstBucket v[INST_BUCKET_COUNT];            \
-    size_t v_index;                             \
-    uint64_t v_startTime
+#define INST_UPDATE_METRIC(v, m, d) instAddToMetric(&v[v##_index].metrics[m], (d))
+#define INST_SET_BUCKET_START(v, d) v##_startTime) = d
+#define INST_BUCKETS_DEFINE(v)                    \
+    InstBucket v[INST_BUCKET_COUNT];              \
+    size_t v##_index;                             \
+    uint64_t v##_startTime
 
 #define INST_BUCKETS_CLEAR(v)                                           \
     memset(v, 0, sizeof(InstBucket) * INST_BUCKET_COUNT);               \
@@ -40,21 +40,21 @@
             }                                                           \
         }                                                               \
     }                                                                   \
-    v_startTime = 0;                                                    \
-    v_index = 0
+    v##_startTime = 0;                                                  \
+    v##_index = 0
 
-#define INST_BUCKETS_HANDLE(v, d, t, i, q)       \
-    q = false;                                   \
-    if(d - v_startTime >= INST_BUCKET_SIZE) {    \
-        v[v_index].duration = d - v_startTime;   \
-        ++v_index;                               \
-        if(v_index == INST_BUCKET_COUNT) {       \
-            instDumpMetricsBuckets(v, t, i);     \
-            INST_BUCKETS_CLEAR(v);               \
-            INST_TS(d);                          \
-            q = true;                            \
-        }                                        \
-        v_startTime = d;                         \
+#define INST_BUCKETS_HANDLE(v, d, t, i, q)           \
+    q = false;                                       \
+    if(d - v##_startTime >= INST_BUCKET_SIZE) {      \
+        v[v##_index].duration = d - v##_startTime;   \
+        ++v##_index;                                 \
+        if(v##_index == INST_BUCKET_COUNT) {         \
+            instDumpMetricsBuckets(v, t, i);         \
+            INST_BUCKETS_CLEAR(v);                   \
+            INST_TS(d);                              \
+            q = true;                                \
+        }                                            \
+        v##_startTime = d;                           \
     }
 
 

--- a/com.ibm.streamsx.network/impl/include/Instrumentation.h
+++ b/com.ibm.streamsx.network/impl/include/Instrumentation.h
@@ -1,0 +1,128 @@
+/*********************************************************************
+ * Copyright (C) 2018 International Business Machines Corporation
+ * All Rights Reserved
+ ********************************************************************/
+
+#ifndef INSTRUMENTATION_H_
+#define INSTRUMENTATION_H_
+
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <x86intrin.h>
+
+
+
+
+#define INST_ENABLE
+
+#define INST_BUCKET_SIZE (60UL * 2194707391UL)
+#define INST_BUCKET_COUNT 10
+#define INST_SCRATCH_SIZE 4096
+#define INST_METRIC_COUNT 2
+#ifdef INST_ENABLE
+#define INST_TS(d) d = __rdtsc()
+#define INST_UPDATE_METRIC(v, m, d) instAddToMetric(&v[v_index].metrics[m], (d))
+#define INST_SET_BUCKET_START(v, d) v_startTime = d
+#define INST_BUCKETS_DEFINE(v)                  \
+    InstBucket v[INST_BUCKET_COUNT];            \
+    size_t v_index;                             \
+    uint64_t v_startTime
+
+#define INST_BUCKETS_CLEAR(v)                                           \
+    memset(v, 0, sizeof(InstBucket) * INST_BUCKET_COUNT);               \
+    {                                                                   \
+        size_t inst_i;                                                  \
+        for(inst_i = 0; inst_i < INST_BUCKET_COUNT; ++inst_i) {         \
+            size_t inst_j;                                              \
+            for(inst_j = 0; inst_j < INST_METRIC_COUNT; ++inst_j) {     \
+                v[inst_i].metrics[inst_j].min = UINT64_MAX;             \
+            }                                                           \
+        }                                                               \
+    }                                                                   \
+    v_startTime = 0;                                                    \
+    v_index = 0
+
+#define INST_BUCKETS_HANDLE(v, d, t, i, q)       \
+    q = false;                                   \
+    if(d - v_startTime >= INST_BUCKET_SIZE) {    \
+        v[v_index].duration = d - v_startTime;   \
+        ++v_index;                               \
+        if(v_index == INST_BUCKET_COUNT) {       \
+            instDumpMetricsBuckets(v, t, i);     \
+            INST_BUCKETS_CLEAR(v);               \
+            INST_TS(d);                          \
+            q = true;                            \
+        }                                        \
+        v_startTime = d;                         \
+    }
+
+
+
+#else
+#define INST_TS(d)
+#define INST_UPDATE_METRIC(v, m, d)
+#define INST_SET_BUCKET_START(v, d)
+#define INST_BUCKETS_DEFINE(v)
+#define INST_BUCKETS_CLEAR(v)
+#define INST_BUCKETS_HANDLE(v, d, t, i, q) q = false
+
+#endif
+
+struct InstMetric {
+    uint64_t count;
+    uint64_t total;
+    uint64_t squareTotal;
+    uint64_t min;
+    uint64_t max;
+};
+
+struct InstBucket {
+    uint64_t duration;
+    struct InstMetric metrics[INST_METRIC_COUNT];
+};
+
+inline __attribute__((always_inline))
+void instAddToMetric(struct InstMetric *m, uint64_t datum) {
+    ++m->count;
+    m->total += datum;
+    m->squareTotal += datum * datum;
+    if(datum < m->min) {
+        m->min = datum;
+    }
+    if(datum > m->max) {
+        m->max = datum;
+    }
+}
+
+inline __attribute__((always_inline))
+void instDumpMetricsBuckets(struct InstBucket *b, const char * tag, size_t index) {
+    char scratch[INST_SCRATCH_SIZE];
+    size_t i = 0;
+    size_t j = 0;
+
+    struct timespec ts_real;
+    clock_gettime(CLOCK_REALTIME, &ts_real);
+
+    for(i = 0; i < INST_BUCKET_COUNT; ++i) {
+        // Display the data for this bucket/thread to stdout for now
+        size_t offset = 0;
+        offset += snprintf(scratch + offset, INST_SCRATCH_SIZE - offset, "%s: METRICS %lu %lu.%09lu-%lu %lu",
+                           tag, (uint64_t)index, ts_real.tv_sec, ts_real.tv_nsec, (uint64_t)INST_BUCKET_COUNT - i - 1, b[i].duration);
+        for(j = 0; j < INST_METRIC_COUNT; ++j) {
+            offset += snprintf(scratch + offset, INST_SCRATCH_SIZE - offset, " : %lu %lu %lu %lu %lu",
+                               b[i].metrics[j].count, b[i].metrics[j].total, b[i].metrics[j].squareTotal, b[i].metrics[j].min, b[i].metrics[j].max);
+        }
+        puts(scratch);
+    }
+}
+
+
+
+
+
+
+
+
+
+#endif

--- a/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
+++ b/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
@@ -8,23 +8,79 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <assert.h>
 #include <atomic>
 
 
 class PacketRingBuffer {
 public:
-    static const size_t ENTRY_SIZE = 2048;
-    static const size_t MAX_DATA = ENTRY_SIZE - sizeof(uint32_t)*2;
-    static const size_t ENTRY_COUNT = 1024*1024;     // Must be a power of 2 for the modulo shortcuts (&) below to be valid.
+    // The entry size and entry count must be powers of 2 for everything to work out right.
+    static const size_t ENTRY_SIZE_BITS = 7;
+    static const size_t ENTRY_COUNT_BITS = 24;
+    static const size_t ENTRY_SIZE = 1 << ENTRY_SIZE_BITS;
+    static const size_t ENTRY_COUNT = 1 << ENTRY_COUNT_BITS;
+    static_assert(ENTRY_SIZE > sizeof(uint32_t)*2, "PacketRingBuffer::ENTRY_SIZE must be large enough for the entry header.");
+    static_assert(ENTRY_SIZE >= 64, "PacketRingBuffer::ENTRY_SIZE must be at least the size of a cache line.");
 
     typedef void (*callback_t)(void* user_data, void* pkt_data, uint32_t pkt_len);
 
 protected:
+    // This entry represents just the initial entry of a given packet in the ring
+    // the other entries are just raw data (in 128 byte chunks), right after this one.
     struct entry {
         uint32_t data_len;
-        uint32_t reserved;
-        uint8_t data[MAX_DATA];
-    } __attribute__((aligned(128)));
+        uint32_t reserved     : 31;
+        uint32_t dummy_packet : 1;   // Indicates this is not actually packet data, and just used to pad the ring.  Ignore on dequeue.
+        uint8_t data[ENTRY_SIZE - sizeof(uint32_t)*2];
+    } __attribute__((aligned(128),packed));
+
+protected:
+    // Helper to compute lengths in the ring, including around the end
+    static constexpr inline size_t length(size_t a, size_t b) {
+        return ((b - a) & (ENTRY_COUNT - 1));
+    }
+
+    // Helper to compute the appropriate next index in the ring, including around the end
+    static constexpr inline size_t next(size_t index, size_t offset) {
+        return ((index + offset) & (ENTRY_COUNT - 1));
+    }
+
+    // Helper to compute the amount of space currently used in the ring
+    // This is used on the consumer side, and yields a lower bound, since
+    // the producer may still be adding things.
+    static constexpr inline size_t used_size(size_t head, size_t tail) {
+        return length(tail, head);
+    }
+
+    // Helper to compute the amount of space currently left in the ring
+    // This is used on the producer side, and yields a lower bound, since
+    // the consumer may be making more room right now.
+    static constexpr inline size_t free_space(size_t head, size_t tail) {
+        return length(head + 1, tail);
+    }
+
+    // Helper to compute the amount of space current left in the ring UP TO BUT NOT PAST THE END OF THE RING!
+    // This is used on the producer side, and yields a lower bound, since
+    // the consumer may be making more room right now.
+    static inline size_t free_space_contiguous(size_t head, size_t tail) {
+        size_t tentative_space = ENTRY_COUNT - (head + 1);
+        size_t total_free_space = (tentative_space + tail) & (ENTRY_COUNT - 1);  // tricky, but if head/tail turned into references to the actual items, ensures each is only read once.
+        return ((total_free_space <= tentative_space) ? total_free_space : (tentative_space + 1));
+    }
+
+    // Helper to convert actual data lengths into the count of ENTRY_SIZE items needed to store it.
+    // Takes into account the header in front of the first entry.
+    static constexpr inline size_t computeEntryCount(size_t data_len) {
+        return (((data_len + sizeof(uint32_t)*2 - 1) >> ENTRY_SIZE_BITS) + 1);
+    }
+
+    // Helper to convert entry counts of ENTRY_SIZE items into a data length.
+    // Takes into account the header in front of the first entry.
+    // This is particularly used when padding the end of the ring, before
+    // adding an item that is too big for the current space left at the end of the ring.
+    static constexpr inline size_t computeDummyLength(size_t count) {
+        return ((count << ENTRY_SIZE_BITS) - sizeof(uint32_t)*2);
+    }
 
 public:
     PacketRingBuffer(): buffer(new entry[ENTRY_COUNT]), head(0), tail(0) {
@@ -38,62 +94,90 @@ public:
 
 
     // Just gets a live estimate of the current number of items in the ring
+    // From the consumer thread, this is a lower bound, since the producer
+    // could still be adding things to the ring.
     size_t size() {
-        size_t lhead = head.load(std::memory_order_relaxed);
-        size_t ltail = tail.load(std::memory_order_relaxed);
-        return ((lhead - ltail) & (ENTRY_COUNT - 1));
+        return used_size(head.load(std::memory_order_relaxed), tail.load(std::memory_order_relaxed));
     }
 
     // Produces an item onto the buffer, if there is room for it
     // Returns true if the item could be added, false otherwise
     bool produce(void *data, uint32_t len) {
-        if(__builtin_expect(len <= MAX_DATA, 1)) {
-            // Should fit into an entry
+        size_t needed_space = computeEntryCount(len);
+        size_t lhead = head.load(std::memory_order_relaxed);
+        size_t ltail = tail.load(std::memory_order_acquire);
+        size_t space = free_space(lhead, ltail);
+        size_t free_space_end = free_space_contiguous(lhead, ltail);
 
-            size_t lhead = head.load(std::memory_order_relaxed);
-            if(__builtin_expect(((tail.load(std::memory_order_acquire) - (lhead + 1)) & (ENTRY_COUNT - 1)) >= 1, 1)) {
-                // Room in the buffer!
-                buffer[lhead].data_len = len;
-                memcpy(buffer[lhead].data, data, len);
+        // Since we are using a local copy of tail, and the computations of free space, we're somewhat pessimistic about what will fit,
+        // but at least it should be self-consistent.
 
-                // Update head
-                head.store(((lhead + 1) & (ENTRY_COUNT - 1)), std::memory_order_release);
-
-                return true;
-            } else {
-                // buffer is full
-                // Unlikely path
+        if(__builtin_expect(needed_space > free_space_end, 0)) {
+            // Doesn't fit in the ring contiguously at the end.
+            // Unlikely path.
+            // Check to see if it would fit in the front (if free space is split).
+            if(__builtin_expect(needed_space > (space - free_space_end), 0)) {
+                // Nope.
+                // Buffer is full.
+                // Unlikely path, even given the earlier unlikely path has been taken.
                 return false;
+            } else {
+                // Seems like it will.  Let's insert a dummy to wrap the buffer.
+                buffer[lhead].data_len = computeDummyLength(free_space_end);
+                buffer[lhead].dummy_packet = 1; // This is just a dummy padding packet
+
+                // Update head (local and actual)
+                lhead = next(lhead, free_space_end);
+                head.store(lhead, std::memory_order_release);
             }
-        } else {
-            // data doesn't fit in one entry.
-            // Caller should have already checked for this,
-            // since we're just going to drop it.
-            // Unlikely path
-            return false;
         }
+
+        // At this point, we know we should fit, contiguously, at the current lhead, or we would
+        // have returned already.  We may have already inserted a dummy padding packet.
+        buffer[lhead].data_len = len;
+        buffer[lhead].dummy_packet = 0; // Real packet.
+        memcpy(buffer[lhead].data, data, len);
+
+        // Update head
+        head.store(next(lhead, needed_space), std::memory_order_release);
+
+        return true;
     }
 
     // Consumes one item from the buffer, if there was an item to consume
     // Returns true if an item was consumed, false otherwise.
     // Calls cb for each packet before removing it from the buffer (if cb specified)
     bool consume(callback_t cb, void *user_data) {
-        size_t lhead = head.load(std::memory_order_acquire);
-        size_t ltail = tail.load(std::memory_order_relaxed);
-        if(((lhead - ltail) & (ENTRY_COUNT - 1)) >= 1) {
-            // Found something in the buffer, so execute the callback on it, if there is one
-            if(__builtin_expect(cb != NULL, 1)) {
-                cb(user_data, buffer[ltail].data, buffer[ltail].data_len);
-            } // else no callback? Unlikely.
+        do {
+            size_t ltail = tail.load(std::memory_order_relaxed);
+            if(used_size(head.load(std::memory_order_acquire), ltail) >= 1) {
+                // Found something in the buffer!
+                size_t skip_len = computeEntryCount(buffer[ltail].data_len);
+                bool dummy_packet = (buffer[ltail].dummy_packet == 1);
 
-            // Update tail
-            tail.store(((ltail + 1) & (ENTRY_COUNT - 1)), std::memory_order_release);
+                if(__builtin_expect(!dummy_packet, 1)) {
+                    // Real packet!
 
-            return true;
-        } else {
-            // buffer is empty
-            return false;
-        }
+                    // Use the callback on it (if there is one)
+                    if(__builtin_expect(cb != NULL, 1)) {
+                        cb(user_data, buffer[ltail].data, buffer[ltail].data_len);
+                    } // else no callback? Unlikely.
+
+                } // else a dummy.  Have to keep going.  Unlikely path.
+
+                // Update tail
+                tail.store(next(ltail, skip_len), std::memory_order_release);
+
+                if(__builtin_expect(!dummy_packet, 1)) {
+                    // Wasn't a dummy. Can return immediately.
+                    return true;
+                } // else a dummy.  Have to keep going.  Unlikely path.
+            } else {
+                // buffer is empty.
+                // We can just return immediately.
+                return false;
+            }
+        } while(__builtin_expect(true, 1));
     }
 
 protected:

--- a/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
+++ b/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
@@ -66,6 +66,9 @@ public:
                 return false;
             }
         } else {
+            // data doesn't fit in one entry.
+            // Caller should have already checked for this,
+            // since we're just going to drop it.
             // Unlikely path
             return false;
         }
@@ -89,7 +92,6 @@ public:
             return true;
         } else {
             // buffer is empty
-            // Unlikely path
             return false;
         }
     }

--- a/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
+++ b/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
@@ -16,7 +16,7 @@ class PacketRingBuffer {
 public:
     // The entry size and entry count must be powers of 2 for everything to work out right.
     static const size_t ENTRY_SIZE_BITS = 7;
-    static const size_t ENTRY_COUNT_BITS = 18;    // 2^15 x 128 byte entries would allow 8 rings to fit in the L3 of one socket, but that's pretty small.
+    static const size_t ENTRY_COUNT_BITS = 19;    // 2^15 x 128 byte entries would allow 8 rings to fit in the L3 of one socket, but that's pretty small.
     static const size_t ENTRY_SIZE = 1 << ENTRY_SIZE_BITS;
     static const size_t ENTRY_COUNT = 1 << ENTRY_COUNT_BITS;
     static_assert(ENTRY_SIZE > sizeof(uint32_t)*2, "PacketRingBuffer::ENTRY_SIZE must be large enough for the entry header.");

--- a/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
+++ b/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
@@ -16,7 +16,7 @@ class PacketRingBuffer {
 public:
     // The entry size and entry count must be powers of 2 for everything to work out right.
     static const size_t ENTRY_SIZE_BITS = 7;
-    static const size_t ENTRY_COUNT_BITS = 24;
+    static const size_t ENTRY_COUNT_BITS = 19;
     static const size_t ENTRY_SIZE = 1 << ENTRY_SIZE_BITS;
     static const size_t ENTRY_COUNT = 1 << ENTRY_COUNT_BITS;
     static_assert(ENTRY_SIZE > sizeof(uint32_t)*2, "PacketRingBuffer::ENTRY_SIZE must be large enough for the entry header.");
@@ -29,8 +29,7 @@ protected:
     // the other entries are just raw data (in 128 byte chunks), right after this one.
     struct entry {
         uint32_t data_len;
-        uint32_t reserved     : 31;
-        uint32_t dummy_packet : 1;   // Indicates this is not actually packet data, and just used to pad the ring.  Ignore on dequeue.
+        uint32_t dummy_packet;   // Indicates (=1) this is not actually packet data, and just used to pad the ring.  Ignore on dequeue. 0 otherwise
         uint8_t data[ENTRY_SIZE - sizeof(uint32_t)*2];
     } __attribute__((aligned(128),packed));
 

--- a/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
+++ b/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
@@ -95,11 +95,10 @@ public:
     }
 
 protected:
-    struct entry * const buffer;
+    struct entry * const buffer __attribute__((aligned(64)));
 
-    // TODO: Do we need to spread these apart somehow, to prevent false sharing?
-    std::atomic<size_t> head;
-    std::atomic<size_t> tail;
+    std::atomic<size_t> head __attribute__((aligned(64)));
+    std::atomic<size_t> tail __attribute__((aligned(64)));
 };
 
 

--- a/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
+++ b/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
@@ -1,0 +1,109 @@
+/*********************************************************************
+ * Copyright (C) 2018 International Business Machines Corporation
+ * All Rights Reserved
+ ********************************************************************/
+
+#ifndef PACKETRING_BUFFER_H_
+#define PACKETRING_BUFFER_H_
+
+#include <stdint.h>
+#include <string.h>
+#include <atomic>
+
+
+class PacketRingBuffer {
+public:
+    static const size_t ENTRY_SIZE = 2048;
+    static const size_t MAX_DATA = ENTRY_SIZE - sizeof(uint32_t)*2;
+    static const size_t ENTRY_COUNT = 1024*1024;     // Must be a power of 2 for the modulo shortcuts (&) below to be valid.
+
+    typedef void (*callback_t)(void* user_data, void* pkt_data, uint32_t pkt_len);
+
+protected:
+    struct entry {
+        uint32_t data_len;
+        uint32_t reserved;
+        uint8_t data[MAX_DATA];
+    } __attribute__((aligned(128)));
+
+public:
+    PacketRingBuffer(): buffer(new entry[ENTRY_COUNT]), head(0), tail(0) {
+        // Make sure the new didn't fail.  We are potentially getting quite a bit of memory here.
+        assert(buffer);
+    }
+
+    ~PacketRingBuffer() {
+        delete [] buffer;
+    }
+
+
+    // Just gets a live estimate of the current number of items in the ring
+    size_t size() {
+        size_t lhead = head.load(std::memory_order_relaxed);
+        size_t ltail = tail.load(std::memory_order_relaxed);
+        return ((lhead - ltail) & (ENTRY_COUNT - 1));
+    }
+
+    // Produces an item onto the buffer, if there is room for it
+    // Returns true if the item could be added, false otherwise
+    bool produce(void *data, uint32_t len) {
+        if(__builtin_expect(len <= MAX_DATA, 1)) {
+            // Should fit into an entry
+
+            size_t lhead = head.load(std::memory_order_relaxed);
+            if(__builtin_expect(((tail.load(std::memory_order_acquire) - (lhead + 1)) & (ENTRY_COUNT - 1)) >= 1, 1)) {
+                // Room in the buffer!
+                buffer[lhead].data_len = len;
+                memcpy(buffer[lhead].data, data, len);
+
+                // Update head
+                head.store(((lhead + 1) & (ENTRY_COUNT - 1)), std::memory_order_release);
+
+                return true;
+            } else {
+                // buffer is full
+                // Unlikely path
+                return false;
+            }
+        } else {
+            // Unlikely path
+            return false;
+        }
+    }
+
+    // Consumes one item from the buffer, if there was an item to consume
+    // Returns true if an item was consumed, false otherwise.
+    // Calls cb for each packet before removing it from the buffer (if cb specified)
+    bool consume(callback_t cb, void *user_data) {
+        size_t lhead = head.load(std::memory_order_acquire);
+        size_t ltail = tail.load(std::memory_order_relaxed);
+        if(((lhead - ltail) & (ENTRY_COUNT - 1)) >= 1) {
+            // Found something in the buffer, so execute the callback on it, if there is one
+            if(__builtin_expect(cb != NULL, 1)) {
+                cb(user_data, buffer[ltail].data, buffer[ltail].data_len);
+            } // else no callback? Unlikely.
+
+            // Update tail
+            tail.store(((ltail + 1) & (ENTRY_COUNT - 1)), std::memory_order_release);
+
+            return true;
+        } else {
+            // buffer is empty
+            // Unlikely path
+            return false;
+        }
+    }
+
+protected:
+    struct entry * const buffer;
+
+    // TODO: Do we need to spread these apart somehow, to prevent false sharing?
+    std::atomic<size_t> head;
+    std::atomic<size_t> tail;
+};
+
+
+
+
+
+#endif

--- a/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
+++ b/com.ibm.streamsx.network/impl/include/PacketRingBuffer.h
@@ -16,7 +16,7 @@ class PacketRingBuffer {
 public:
     // The entry size and entry count must be powers of 2 for everything to work out right.
     static const size_t ENTRY_SIZE_BITS = 7;
-    static const size_t ENTRY_COUNT_BITS = 19;
+    static const size_t ENTRY_COUNT_BITS = 18;
     static const size_t ENTRY_SIZE = 1 << ENTRY_SIZE_BITS;
     static const size_t ENTRY_COUNT = 1 << ENTRY_COUNT_BITS;
     static_assert(ENTRY_SIZE > sizeof(uint32_t)*2, "PacketRingBuffer::ENTRY_SIZE must be large enough for the entry header.");

--- a/com.ibm.streamsx.network/impl/include/dns/DNSPacketFlattener.h
+++ b/com.ibm.streamsx.network/impl/include/dns/DNSPacketFlattener.h
@@ -370,7 +370,10 @@ DNSResponseNames dnsResponseNames;
  public:
 
   SPL::rstring dnsAllFields(double captureTime, uint32_t packetLength, NetworkHeaderParser& headers, DNSMessageParser& parser, const char* recordDelimiter, const char* fieldDelimiter, const char* subfieldDelimiter, SPL::list<SPL::uint16>& rrTypes) {
+    return dnsAllFields(captureTime, packetLength, headers.ipv4Header->saddr, headers.ipv4Header->daddr, headers.udpHeader->source, headers.udpHeader->dest, parser, recordDelimiter, fieldDelimiter, subfieldDelimiter, rrTypes);
+  }
 
+  SPL::rstring dnsAllFields(double captureTime, uint32_t packetLength, uint32_t srcAddr, uint32_t dstAddr, uint16_t udpSrcPort, uint16_t udpDstPort, DNSMessageParser& parser, const char* recordDelimiter, const char* fieldDelimiter, const char* subfieldDelimiter, SPL::list<SPL::uint16>& rrTypes) {
     // allocate a buffer large enough to hold the largest possible string representation of a DNS message
     char buffer[1024*1024];
     size_t bufferLength = 0;
@@ -388,11 +391,11 @@ DNSResponseNames dnsResponseNames;
                               "%s%ssource=%s:%hu%sdestination=%s:%hu parseError=%d,'%s'%s",
                               formatTimestamp(captureTime, "%Y-%m-%d %H:%M:%S", timestampBuffer), 
                               fieldDelimiter,
-                              convertIPV4AddressToString(headers.ipv4Header->saddr, sourceAddressBuffer),
-                              ntohs(headers.udpHeader->source), 
+                              convertIPV4AddressToString(srcAddr, sourceAddressBuffer),
+                              ntohs(udpSrcPort), 
                               fieldDelimiter,
-                              convertIPV4AddressToString(headers.ipv4Header->daddr, destinationAddressBuffer), 
-                              ntohs(headers.udpHeader->dest), 
+                              convertIPV4AddressToString(dstAddr, destinationAddressBuffer), 
+                              ntohs(udpDstPort), 
                               parser.error,
                               parser.errorDescriptions.description[parser.error],
                               recordDelimiter );

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/config.h
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/config.h
@@ -46,7 +46,7 @@
 #define EM_TX_WTHRESH 8  /**< Default values of TX write-back threshold reg. */
 
 #define MAX_RX_QUEUE_PER_LCORE 4
-#define MAX_PKT_BURST  32
+#define MAX_PKT_BURST  128
 #define BURST_TX_DRAIN 220000ULL /* around 100us at 2.2 Ghz */
 
 /*
@@ -59,6 +59,7 @@
 #define STREAMS_SOURCE_RX_DESC_DEFAULT 512
 #define STREAMS_SOURCE_TX_DESC_DEFAULT 64
 #else
+// For the Intel x520, 4096 is the max number of RX descriptors
 #define STREAMS_SOURCE_RX_DESC_DEFAULT 4096
 #define STREAMS_SOURCE_TX_DESC_DEFAULT 64
 #endif

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/init.c
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/init.c
@@ -195,6 +195,10 @@ static void init_ports(void) {
 		"  RXQ Max      : %d\n", dev_info.max_rx_queues); 
 	RTE_LOG(INFO, STREAMS_SOURCE, 
 		"  TXQ Max      : %d\n", dev_info.max_tx_queues); 
+    RTE_LOG(INFO, STREAMS_SOURCE,
+        "  RX Desc Max  : %d\n", dev_info.rx_desc_lim.nb_max);
+    RTE_LOG(INFO, STREAMS_SOURCE,
+        "  RX Desc Min  : %d\n", dev_info.rx_desc_lim.nb_min);
 
 	num_rx_queues = numQueues_;
 	num_tx_queues = 1;

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/process_dpdk_inst_data.pl
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/process_dpdk_inst_data.pl
@@ -1,0 +1,390 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+# Feed the pec.pe.*.stdouterr file to this script on STDIN
+# It will ignore the startup data, and process just the DPDK METRICS data that pops out.
+
+our $TSC_HZ = 2194714309;
+our $old_new = undef;
+
+our $state = {entries=>{}, all=>[]};
+
+while(<>) {
+    chomp;
+    if(/^STREAMS_SOURCE: TSC Hz = ([[:digit:]]+)$/) {
+        $TSC_HZ = $1;
+    } elsif(/^RXTX: receive_loop: METRICS (.*)$/) {
+        my @groups = split / : /,$1;
+
+        if(!defined $old_new) {
+            $old_new = scalar @groups;
+        }
+
+        if(scalar @groups <= $old_new) {
+            if(scalar @groups > 0) {
+                if($old_new == 6) {
+                    # old code
+                    processOldEntry($state, @groups);
+                } elsif($old_new == 7 || $old_new == 8) {
+                    # new code
+                    processNewEntry($state, @groups);
+                } else {
+                    # ?
+                    die "ERROR: Initial line had invalid number of groups ($old_new)\n";
+                }
+            } else {
+                printf STDERR "WARNING: Found line with no initial group\n";
+            }
+        } else {
+            # too many groups!  bad!
+            die "ERROR: Found line with too many groups (".(scalar @groups).", expected $old_new)\n";
+        }
+    } else {
+        # ignore everything else.
+    }
+}
+
+if($old_new == 6) {
+    postProcessOld($state);
+    displayOld($state);
+} elsif($old_new == 7 || $old_new == 8) {
+    postProcessNew($state);
+    displayNew($state);
+} else {
+    die "ERROR: How did I get this far with the initial group count at $old_new?\n";
+}
+
+exit(0);
+
+
+
+
+sub processOldEntry {
+    my ($s, @g) = @_;
+
+    my $e = {};
+    my $qid;
+    (undef, undef, $qid, $e->{ts}, $e->{waste}, $e->{dur}) = split /\s+/,$g[0];
+    #print "Entry for $qid\n";
+    if(scalar @g == 6) {
+        ($e->{none_count}, $e->{none_time}, $e->{none_tsquare}, $e->{none_min}, $e->{none_max}) = split /\s+/,$g[1];
+        ($e->{burst_count}, $e->{burst_time}, $e->{burst_tsquare}, $e->{burst_min}, $e->{burst_max}) = split /\s+/,$g[2];
+        ($e->{pkt_count}, $e->{pkt_square}, $e->{pkt_min}, $e->{pkt_max}) = split /\s+/,$g[3];
+        ($e->{call_time}, $e->{call_tsquare}, $e->{call_min}, $e->{call_max}) = split /\s+/,$g[4];
+        ($e->{free_time}, $e->{free_tsquare}, $e->{free_min}, $e->{free_max}) = split /\s+/,$g[5];
+    }
+    if($qid !~ /^[[:digit:]]+/) {
+        print STDERR "WARNING: Found invalid queue id [$qid]\n";
+        return;
+    }
+    if(!defined $e->{free_max}) {
+        $s->{entries}->{$qid} = [] if !defined $s->{entries}->{$qid};
+        push @{$s->{entries}->{$qid}}, undef;
+
+        print STDERR "WARNING: Found line for $qid with short last group.\n";
+        return;
+    } elsif((scalar (split /\s+/,$g[5])) > 4) {
+        $s->{entries}->{$qid} = [] if !defined $s->{entries}->{$qid};
+        push @{$s->{entries}->{$qid}}, undef;
+
+        print STDERR "WARNING: Found line for $qid with long last group.\n";
+        return;
+    }
+
+    # Can already compute the averages and stddev
+    if($e->{none_count}) {
+        $e->{avg_none_time} = $e->{none_time} / $e->{none_count};
+        $e->{sdev_none_time} = sqrt($e->{none_tsquare}/$e->{none_count} - $e->{avg_none_time} * $e->{avg_none_time});
+    }
+    $e->{avg_burst_time} = $e->{burst_time} / $e->{burst_count};
+    $e->{avg_burst_pkts} = $e->{pkt_count} / $e->{burst_count};
+    $e->{avg_burst_time_per_pkt} = $e->{burst_time} / $e->{pkt_count};
+    $e->{avg_call_time} = $e->{call_time} / $e->{pkt_count};
+    $e->{avg_free_time} = $e->{free_time} / $e->{pkt_count};
+    $e->{sdev_burst_time} = sqrt($e->{burst_tsquare}/$e->{burst_count} - $e->{avg_burst_time} * $e->{avg_burst_time});
+    $e->{sdev_burst_pkts} = sqrt($e->{pkt_square}/$e->{burst_count} - $e->{avg_burst_pkts} * $e->{avg_burst_pkts});
+    $e->{sdev_burst_time_per_pkt} = $e->{sdev_burst_time}/$e->{avg_burst_pkts};
+    $e->{sdev_call_time} = sqrt($e->{call_tsquare}/$e->{pkt_count} - $e->{avg_call_time} * $e->{avg_call_time});
+    $e->{sdev_free_time} = sqrt($e->{free_tsquare}/$e->{pkt_count} - $e->{avg_free_time} * $e->{avg_free_time});
+
+    $s->{entries}->{$qid} = [] if !defined $s->{entries}->{$qid};
+    push @{$s->{entries}->{$qid}}, $e;
+}
+
+sub postProcessOld {
+    my ($s) = @_;
+
+    my @qids = keys %{$s->{entries}};
+#    print "ppo: $qids[0] has ".(scalar @{$s->{entries}->{$qids[0]}})." entries.\n";
+    GROUP: for(my $i = 0; $i < scalar @{$s->{entries}->{$qids[0]}}; ++$i) {
+        foreach(@qids) {
+#            print "Checking $_\n";
+            if(!defined $s->{entries}->{$_}->[$i]) {
+                next GROUP;
+            }
+#            print "$_ has entry $i\n";
+        }
+#        print "Handling entry $i\n";
+        # combine all the queue data into data for this point.
+        # We want to use the timestamp of the first queue, I guess
+        # - sum of pkt_count
+        # - new average of burst time per pkt
+        # - new stddev of burst time per pkt
+        # - new average of call time per pkt
+        # - new stddev of call time per pkt
+        # - new average of free time per pkt
+        # - new stddev of free time per pkt
+
+        # - average total time per pkt
+        # - sdev total time per pkt
+        # - back-computed pkt rate possible
+        # - forward-computed pkt rate in interval
+
+        my $e = {};
+        $e->{ts} = $s->{entries}->{$qids[0]}->[$i]->{ts};
+
+        $e->{dur} = 0;
+        $e->{pkts} = 0;
+        $e->{bursts} = 0;
+        $e->{avg_ppb} = 0;
+        $e->{avg_rxpp} = 0;
+        $e->{avg_callpp} = 0;
+        $e->{avg_freepp} = 0;
+        $e->{sdev_ppb} = 0;
+        $e->{sdev_rxpp} = 0;
+        $e->{sdev_callpp} = 0;
+        $e->{sdev_freepp} = 0;
+        foreach(@qids) {
+            my $d = $s->{entries}->{$_}->[$i];
+            $e->{dur} += $d->{dur};
+            $e->{pkts} += $d->{pkt_count};
+            $e->{bursts} += $d->{burst_count};
+            $e->{avg_ppb} += $d->{avg_burst_pkts} * $d->{burst_count};
+            $e->{avg_rxpp} += $d->{avg_burst_time_per_pkt} * $d->{pkt_count};
+            $e->{avg_callpp} += $d->{avg_call_time} * $d->{pkt_count};
+            $e->{avg_freepp} += $d->{avg_free_time} * $d->{pkt_count};
+        }
+
+        $e->{dur} /= scalar @qids;
+        $e->{avg_ppb} /= $e->{bursts};
+        $e->{avg_rxpp} /= $e->{pkts};
+        $e->{avg_callpp} /= $e->{pkts};
+        $e->{avg_freepp} /= $e->{pkts};
+
+        foreach(@qids) {
+            my $d = $s->{entries}->{$_}->[$i];
+            $e->{sdev_ppb} += ($d->{sdev_burst_pkts} * $d->{sdev_burst_pkts} + (($d->{avg_burst_pkts} - $e->{avg_ppb})**2.0)) * $d->{burst_count};
+            $e->{sdev_rxpp} += ($d->{sdev_burst_time_per_pkt} * $d->{sdev_burst_time_per_pkt}  + (($d->{avg_burst_time_per_pkt} - $e->{avg_rxpp})**2.0)) * $d->{pkt_count};
+            $e->{sdev_callpp} += ($d->{sdev_call_time} * $d->{sdev_call_time}  + (($d->{avg_call_time} - $e->{avg_callpp})**2.0)) * $d->{pkt_count};
+            $e->{sdev_freepp} += ($d->{sdev_free_time} * $d->{sdev_free_time}  + (($d->{avg_free_time} - $e->{avg_freepp})**2.0)) * $d->{pkt_count};
+        }
+
+        $e->{sdev_ppb} /= $e->{bursts};
+        $e->{sdev_rxpp} /= $e->{pkts};
+        $e->{sdev_callpp} /= $e->{pkts};
+        $e->{sdev_freepp} /= $e->{pkts};
+        $e->{sdev_ppb} = sqrt($e->{sdev_ppb});
+        $e->{sdev_rxpp} = sqrt($e->{sdev_rxpp});
+        $e->{sdev_callpp} = sqrt($e->{sdev_callpp});
+        $e->{sdev_freepp} = sqrt($e->{sdev_freepp});
+
+
+        $e->{avg_total} = $e->{avg_rxpp} + $e->{avg_callpp} + $e->{avg_freepp};
+        $e->{sdev_total} = sqrt($e->{sdev_rxpp}*$e->{sdev_rxpp} + $e->{sdev_callpp}*$e->{sdev_callpp} + $e->{sdev_freepp}*$e->{sdev_freepp});
+
+        $e->{avg_rate} = $e->{pkts}/($e->{dur}/$TSC_HZ);
+
+        $e->{avg_comp_rate} = (scalar @qids) * $TSC_HZ / $e->{avg_total};
+        $e->{min_comp_rate} = (scalar @qids) * $TSC_HZ / ($e->{avg_total} + $e->{sdev_total});
+        $e->{max_comp_rate} = (scalar @qids) * $TSC_HZ / ($e->{avg_total} - $e->{sdev_total});
+
+        push @{$s->{all}}, $e;
+
+    }
+
+}
+
+sub displayOld {
+    my ($s) = @_;
+
+    foreach(@{$s->{all}}) {
+        my $e = $_;
+        printf("%20.6f %10d %3d %3d    %9d %9d    %9d %9d    %9d %9d    %9d %9d    %12.6f %12.6f\n",
+               $e->{ts}, $e->{pkts}, $e->{avg_ppb}, $e->{sdev_ppb}, $e->{avg_rxpp}, $e->{sdev_rxpp}, $e->{avg_callpp}, $e->{sdev_callpp}, $e->{avg_freepp}, $e->{sdev_freepp},
+               $e->{avg_total}, $e->{sdev_total}, $e->{avg_rate}/1000000, $e->{avg_comp_rate}/1000000);
+    }
+}
+
+
+
+
+
+
+sub processNewEntry {
+    my ($s, @g) = @_;
+
+    my $e = {};
+    my $qid;
+
+    (undef, undef, $qid, $e->{ts_offs}, $e->{waste}, $e->{dur}) = split /\s+/,$g[0];
+    if($qid !~ /^[[:digit:]]+$/ || $e->{ts_offs} !~ /^[[:digit:].-]+$/ || $e->{dur} !~ /^[[:digit:]]+$/) {
+        print STDERR "WARNING: Found invalid queue id [$qid] or ts_offs [$e->{ts_offs}] or dur [$e->{dur}]\n";
+        return;
+    }
+    ($e->{ts}, $e->{offs}) = split '-',$e->{ts_offs};
+    $e->{ts} -= $e->{dur}/$TSC_HZ * $e->{offs};
+    if(scalar @g == 7 || scalar @g == 8) {
+#        ($e->{nic_packets},$e->{nic_bytes}, $e->{nic_missed}, $e->{nic_errors}, $e->{nic_rnb}) = split /\s+/, $g[1];
+
+        $e->{m} = [];
+        for(my $i = 0; $i < 5; ++$i) {
+            $e->{m}->[$i] = {};
+            ($e->{m}->[$i]->{count}, $e->{m}->[$i]->{total}, $e->{m}->[$i]->{tsquare}, $e->{m}->[$i]->{min}, $e->{m}->[$i]->{max}) = split /\s+/, $g[$i+2];
+        }
+    }
+    if(!defined $e->{m}->[4]->{max} || $e->{m}->[4]->{max} !~ /^[[:digit:]]+$/) {
+        $s->{entries}->{$qid} = [] if !defined $s->{entries}->{$qid};
+        push @{$s->{entries}->{$qid}}, undef;
+
+        print STDERR "WARNING: Found line with short last group.\n";
+        return;
+    } elsif((scalar (split /\s+/,$g[6])) > 5) {
+        $s->{entries}->{$qid} = [] if !defined $s->{entries}->{$qid};
+        push @{$s->{entries}->{$qid}}, undef;
+
+        print STDERR "WARNING: Found line with long last group.\n";
+        return;
+    }
+
+
+    foreach(@{$e->{m}}) {
+        my $m = $_;
+        if($m->{count}) {
+            $m->{avg} = $m->{total}/$m->{count};
+            $m->{sdev} = sqrt($m->{tsquare}/$m->{count} - $m->{avg}*$m->{avg});
+        }
+    }
+
+    # For burst time metric, compute the per-pkt averages
+    # Not sure how to handle the standard deviation here...
+    if($e->{m}->[0]->{total}) {
+        $e->{avg_burst_time_per_pkt} = $e->{m}->[1]->{total}/$e->{m}->[0]->{total};
+        $e->{sdev_burst_time_per_pkt} = $e->{m}->[1]->{sdev}/$e->{m}->[0]->{avg};
+    }
+
+    $s->{entries}->{$qid} = [] if !defined $s->{entries}->{$qid};
+    push @{$s->{entries}->{$qid}}, $e;
+}
+
+sub postProcessNew {
+    my ($s) = @_;
+
+
+
+    my @qids = keys %{$s->{entries}};
+#    print "ppo: $qids[0] has ".(scalar @{$s->{entries}->{$qids[0]}})." entries.\n";
+    GROUP: for(my $i = 0; $i < scalar @{$s->{entries}->{$qids[0]}}; ++$i) {
+        foreach(@qids) {
+#            print "Checking $_\n";
+            if(!defined $s->{entries}->{$_}->[$i]) {
+                next GROUP;
+            }
+#            print "$_ has entry $i\n";
+        }
+#        print "Handling entry $i\n";
+        # combine all the queue data into data for this point.
+        # We want to use the timestamp of the first queue, I guess
+        # - sum of pkt_count
+        # - new average of burst time per pkt
+        # - new stddev of burst time per pkt
+        # - new average of call time per pkt
+        # - new stddev of call time per pkt
+        # - new average of free time per pkt
+        # - new stddev of free time per pkt
+
+        # - average total time per pkt
+        # - sdev total time per pkt
+        # - back-computed pkt rate possible
+        # - forward-computed pkt rate in interval
+
+        my $e = {};
+        $e->{ts} = $s->{entries}->{$qids[0]}->[$i]->{ts};
+
+        $e->{dur} = 0;
+        $e->{pkts} = 0;
+        $e->{bursts} = 0;
+        $e->{avg_ppb} = 0;
+        $e->{avg_rxpp} = 0;
+        $e->{avg_callpp} = 0;
+        $e->{avg_freepp} = 0;
+        $e->{sdev_ppb} = 0;
+        $e->{sdev_rxpp} = 0;
+        $e->{sdev_callpp} = 0;
+        $e->{sdev_freepp} = 0;
+        foreach(@qids) {
+            my $d = $s->{entries}->{$_}->[$i];
+            $e->{dur} += $d->{dur};
+            $e->{pkts} += $d->{m}->[0]->{total};
+            $e->{bursts} += $d->{m}->[0]->{count};
+            $e->{avg_ppb} += $d->{m}->[0]->{avg} * $d->{m}->[0]->{count};
+            $e->{avg_rxpp} += $d->{avg_burst_time_per_pkt} * $d->{m}->[0]->{total};
+            $e->{avg_callpp} += $d->{m}->[3]->{avg} * $d->{m}->[0]->{total};
+            $e->{avg_freepp} += $d->{m}->[4]->{avg} * $d->{m}->[0]->{total};
+        }
+
+        $e->{dur} /= scalar @qids;
+        $e->{avg_ppb} /= $e->{bursts};
+        $e->{avg_rxpp} /= $e->{pkts};
+        $e->{avg_callpp} /= $e->{pkts};
+        $e->{avg_freepp} /= $e->{pkts};
+
+        foreach(@qids) {
+            my $d = $s->{entries}->{$_}->[$i];
+            $e->{sdev_ppb} += ($d->{m}->[0]->{sdev} * $d->{m}->[0]->{sdev} + (($d->{m}->[0]->{avg} - $e->{avg_ppb})**2.0)) * $d->{m}->[0]->{count};
+            $e->{sdev_rxpp} += ($d->{sdev_burst_time_per_pkt} * $d->{sdev_burst_time_per_pkt}  + (($d->{avg_burst_time_per_pkt} - $e->{avg_rxpp})**2.0)) * $d->{m}->[0]->{total};
+            $e->{sdev_callpp} += ($d->{m}->[3]->{sdev} * $d->{m}->[3]->{sdev}  + (($d->{m}->[3]->{avg} - $e->{avg_callpp})**2.0)) * $d->{m}->[0]->{total};
+            $e->{sdev_freepp} += ($d->{m}->[4]->{sdev} * $d->{m}->[4]->{sdev}  + (($d->{m}->[4]->{avg} - $e->{avg_freepp})**2.0)) * $d->{m}->[0]->{total};
+        }
+
+        $e->{sdev_ppb} /= $e->{bursts};
+        $e->{sdev_rxpp} /= $e->{pkts};
+        $e->{sdev_callpp} /= $e->{pkts};
+        $e->{sdev_freepp} /= $e->{pkts};
+        $e->{sdev_ppb} = sqrt($e->{sdev_ppb});
+        $e->{sdev_rxpp} = sqrt($e->{sdev_rxpp});
+        $e->{sdev_callpp} = sqrt($e->{sdev_callpp});
+        $e->{sdev_freepp} = sqrt($e->{sdev_freepp});
+
+
+        $e->{avg_total} = $e->{avg_rxpp} + $e->{avg_callpp} + $e->{avg_freepp};
+        $e->{sdev_total} = sqrt($e->{sdev_rxpp}*$e->{sdev_rxpp} + $e->{sdev_callpp}*$e->{sdev_callpp} + $e->{sdev_freepp}*$e->{sdev_freepp});
+
+        $e->{avg_rate} = $e->{pkts}/($e->{dur}/$TSC_HZ);
+
+        $e->{avg_comp_rate} = (scalar @qids) * $TSC_HZ / $e->{avg_total};
+        $e->{min_comp_rate} = (scalar @qids) * $TSC_HZ / ($e->{avg_total} + $e->{sdev_total});
+        $e->{max_comp_rate} = (scalar @qids) * $TSC_HZ / ($e->{avg_total} - $e->{sdev_total});
+
+        push @{$s->{all}}, $e;
+
+    }
+
+
+
+
+
+}
+
+sub displayNew {
+    my ($s) = @_;
+
+    foreach(@{$s->{all}}) {
+        my $e = $_;
+        printf("%20.6f %10d %3d %3d    %9d %9d    %9d %9d    %9d %9d    %9d %9d    %12.6f %12.6f\n",
+               $e->{ts}, $e->{pkts}, $e->{avg_ppb}, $e->{sdev_ppb}, $e->{avg_rxpp}, $e->{sdev_rxpp}, $e->{avg_callpp}, $e->{sdev_callpp}, $e->{avg_freepp}, $e->{sdev_freepp},
+               $e->{avg_total}, $e->{sdev_total}, $e->{avg_rate}/1000000, $e->{avg_comp_rate}/1000000);
+    }
+}
+

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/process_dpdk_inst_data.pl
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/process_dpdk_inst_data.pl
@@ -148,6 +148,8 @@ sub postProcessOld {
         $e->{dur} = 0;
         $e->{pkts} = 0;
         $e->{bursts} = 0;
+        $e->{min_ppb} = 9999999;
+        $e->{max_ppb} = 0;
         $e->{avg_ppb} = 0;
         $e->{avg_rxpp} = 0;
         $e->{avg_callpp} = 0;
@@ -161,6 +163,8 @@ sub postProcessOld {
             $e->{dur} += $d->{dur};
             $e->{pkts} += $d->{pkt_count};
             $e->{bursts} += $d->{burst_count};
+            $e->{min_ppb} = $d->{burst_min} if $d->{burst_min} < $e->{min_ppb};
+            $e->{max_ppb} = $d->{burst_max} if $d->{burst_max} > $e->{max_ppb};
             $e->{avg_ppb} += $d->{avg_burst_pkts} * $d->{burst_count};
             $e->{avg_rxpp} += $d->{avg_burst_time_per_pkt} * $d->{pkt_count};
             $e->{avg_callpp} += $d->{avg_call_time} * $d->{pkt_count};
@@ -211,8 +215,8 @@ sub displayOld {
 
     foreach(@{$s->{all}}) {
         my $e = $_;
-        printf("%20.6f %10d %3d %3d    %9d %9d    %9d %9d    %9d %9d    %9d %9d    %12.6f %12.6f\n",
-               $e->{ts}, $e->{pkts}, $e->{avg_ppb}, $e->{sdev_ppb}, $e->{avg_rxpp}, $e->{sdev_rxpp}, $e->{avg_callpp}, $e->{sdev_callpp}, $e->{avg_freepp}, $e->{sdev_freepp},
+        printf("%20.6f %10d %3d %3d %3d %3d    %9d %9d    %9d %9d    %9d %9d    %9d %9d    %12.6f %12.6f\n",
+               $e->{ts}, $e->{pkts}, $e->{avg_ppb}, $e->{sdev_ppb}, $e->{min_ppb}, $e->{max_ppb}, $e->{avg_rxpp}, $e->{sdev_rxpp}, $e->{avg_callpp}, $e->{sdev_callpp}, $e->{avg_freepp}, $e->{sdev_freepp},
                $e->{avg_total}, $e->{sdev_total}, $e->{avg_rate}/1000000, $e->{avg_comp_rate}/1000000);
     }
 }
@@ -315,6 +319,8 @@ sub postProcessNew {
         $e->{dur} = 0;
         $e->{pkts} = 0;
         $e->{bursts} = 0;
+        $e->{min_ppb} = 9999999;
+        $e->{max_ppb} = 0;
         $e->{avg_ppb} = 0;
         $e->{avg_rxpp} = 0;
         $e->{avg_callpp} = 0;
@@ -328,6 +334,8 @@ sub postProcessNew {
             $e->{dur} += $d->{dur};
             $e->{pkts} += $d->{m}->[0]->{total};
             $e->{bursts} += $d->{m}->[0]->{count};
+            $e->{min_ppb} = $d->{m}->[0]->{min} if $d->{m}->[0]->{min} < $e->{min_ppb};
+            $e->{max_ppb} = $d->{m}->[0]->{max} if $d->{m}->[0]->{max} > $e->{max_ppb};
             $e->{avg_ppb} += $d->{m}->[0]->{avg} * $d->{m}->[0]->{count};
             $e->{avg_rxpp} += $d->{avg_burst_time_per_pkt} * $d->{m}->[0]->{total};
             $e->{avg_callpp} += $d->{m}->[3]->{avg} * $d->{m}->[0]->{total};
@@ -382,8 +390,8 @@ sub displayNew {
 
     foreach(@{$s->{all}}) {
         my $e = $_;
-        printf("%20.6f %10d %3d %3d    %9d %9d    %9d %9d    %9d %9d    %9d %9d    %12.6f %12.6f\n",
-               $e->{ts}, $e->{pkts}, $e->{avg_ppb}, $e->{sdev_ppb}, $e->{avg_rxpp}, $e->{sdev_rxpp}, $e->{avg_callpp}, $e->{sdev_callpp}, $e->{avg_freepp}, $e->{sdev_freepp},
+        printf("%20.6f %10d %3d %3d %3d %3d    %9d %9d    %9d %9d    %9d %9d    %9d %9d    %12.6f %12.6f\n",
+               $e->{ts}, $e->{pkts}, $e->{avg_ppb}, $e->{sdev_ppb}, $e->{min_ppb}, $e->{max_ppb}, $e->{avg_rxpp}, $e->{sdev_rxpp}, $e->{avg_callpp}, $e->{sdev_callpp}, $e->{avg_freepp}, $e->{sdev_freepp},
                $e->{avg_total}, $e->{sdev_total}, $e->{avg_rate}/1000000, $e->{avg_comp_rate}/1000000);
     }
 }

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/rxtx.c
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/rxtx.c
@@ -12,7 +12,7 @@
 #include "config.h"
 #include <time.h>
 
-#define DPDK_INST_ENABLE
+//#define DPDK_INST_ENABLE
 
 #define DPDK_INST_BUCKET_SIZE 60UL
 #define DPDK_INST_BUCKET_COUNT 10

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/rxtx.c
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/rxtx.c
@@ -18,7 +18,7 @@
 #define DPDK_INST_BUCKET_COUNT 10
 #define DPDK_INST_SCRATCH_SIZE 4096
 #ifdef DPDK_INST_ENABLE
-#define DPDK_INST_TS(var) var = rte_rdtsc_precise()
+#define DPDK_INST_TS(var) var = rte_rdtsc()
 #define DPDK_INST_UPDATE_METRIC(m, d) addToMetric(&buckets[bucketIndex].m, (d))
 #else
 #define DPDK_INST_TS(var)

--- a/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/rxtx.c
+++ b/com.ibm.streamsx.network/impl/src/source/dpdk/streams_source/rxtx.c
@@ -10,12 +10,55 @@
 #include <rte_mbuf.h>
 #include "rxtx.h"
 #include "config.h"
+#include <time.h>
+
+#define DPDK_INST_ENABLE
+
+#define DPDK_INST_BUCKET_SIZE 60000000000UL
+#ifdef DPDK_INST_ENABLE
+#define DPDK_INST_DELTA_TS_START clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts_before)
+#define DPDK_INST_DELTA_TS_END   clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts_after); \
+    deltaT = (ts_after.tv_sec - ts_before.tv_sec)*1000000000UL + ts_after.tv_nsec - ts_before.tv_nsec
+
+#else
+#define DPDK_INST_DELTA_TS_START
+#define DPDK_INST_DELTA_TS_END
+#endif
 
 #define PREFETCH_OFFSET 1
 void receive_loop(struct lcore_conf *conf) {
     struct rte_mbuf *pkts_burst[MAX_PKT_BURST];
     unsigned i, portid;
     int j, num_rx, count;
+
+#ifdef DPDK_INST_ENABLE
+    // The instrumentation variables
+    uint64_t bucketStartTime = 0;
+    uint64_t bucketPriorWastedTime = 0;
+    uint64_t bucketBurstFoundCount = 0;
+    uint64_t bucketNoneFoundCount = 0;
+    uint64_t bucketPacketCountTotal = 0;
+    uint64_t bucketPacketCountSquareTotal = 0;
+    uint64_t bucketPacketCountMin = UINT64_MAX;
+    uint64_t bucketPacketCountMax = 0;
+    uint64_t bucketBurstFoundDurationTotal = 0;
+    uint64_t bucketBurstFoundDurationSquareTotal = 0;
+    uint64_t bucketBurstFoundDurationMin = UINT64_MAX;
+    uint64_t bucketBurstFoundDurationMax = 0;
+    uint64_t bucketNoneFoundDurationTotal = 0;
+    uint64_t bucketNoneFoundDurationSquareTotal = 0;
+    uint64_t bucketNoneFoundDurationMin = UINT64_MAX;
+    uint64_t bucketNoneFoundDurationMax = 0;
+    uint64_t bucketCallbackDurationTotal = 0;
+    uint64_t bucketCallbackDurationSquareTotal = 0;
+    uint64_t bucketCallbackDurationMin = UINT64_MAX;
+    uint64_t bucketCallbackDurationMax = 0;
+    uint64_t bucketPacketFreeDurationTotal = 0;
+    uint64_t bucketPacketFreeDurationSquareTotal = 0;
+    uint64_t bucketPacketFreeDurationMin = UINT64_MAX;
+    uint64_t bucketPacketFreeDurationMax = 0;
+#endif
+
 
     RTE_LOG(INFO, STREAMS_SOURCE, "Starting receive loop on lcore %u\n",
 	    rte_lcore_id());
@@ -28,14 +71,57 @@ void receive_loop(struct lcore_conf *conf) {
                 conf->rx_queue_list[i].queue_id);
     }
 
+#ifdef DPDK_INST_ENABLE
+    // Some other timestamp holders
+    struct timespec ts_before;
+    struct timespec ts_after;
+    uint64_t deltaT;
+
+    // save this off for easier display
+    unsigned lcore_id = rte_lcore_id();
+    int port_id = conf->rx_queue_list[0].port_id;
+    int queue_id = conf->rx_queue_list[0].queue_id;
+
+    // Get the timestamp we started the first bucket
+    struct timespec ts_loop;
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts_loop);
+    bucketStartTime = ts_loop.tv_nsec + ts_loop.tv_sec * 1000000000UL;
+#endif
+
     while(1) {
 	// Read rx packets from the queue.
 	for (i = 0; i < conf->num_rx_queue; i++) {
 	    portid = conf->rx_queue_list[i].port_id;
 	    streams_packet_cb_t packetCallback = conf->rx_queue_list[i].packetCallbackFunction;
+
+            DPDK_INST_DELTA_TS_START;
 	    num_rx = rte_eth_rx_burst((uint32_t) portid, conf->rx_queue_list[i].queue_id,
 		                      pkts_burst, MAX_PKT_BURST);
+            DPDK_INST_DELTA_TS_END;
+
 	    if (num_rx) {
+#ifdef DPDK_INST_ENABLE
+                ++bucketBurstFoundCount;
+
+                bucketPacketCountTotal += num_rx;
+                bucketPacketCountSquareTotal += num_rx * num_rx;
+                if(num_rx < bucketPacketCountMin) {
+                    bucketPacketCountMin = num_rx;
+                }
+                if(num_rx > bucketPacketCountMax) {
+                    bucketPacketCountMax = num_rx;
+                }
+
+                bucketBurstFoundDurationTotal += deltaT;
+                bucketBurstFoundDurationSquareTotal += deltaT*deltaT;
+                if(deltaT < bucketBurstFoundDurationMin) {
+                    bucketBurstFoundDurationMin = deltaT;
+                }
+                if(deltaT > bucketBurstFoundDurationMax) {
+                    bucketBurstFoundDurationMax = deltaT;
+                }
+#endif
+
 		for (j = 0; j < PREFETCH_OFFSET && j < num_rx; j++) {
 		    rte_prefetch0(rte_pktmbuf_mtod(pkts_burst[j], void *));
 		}
@@ -45,25 +131,143 @@ void receive_loop(struct lcore_conf *conf) {
 				+ PREFETCH_OFFSET], void *));
 
                     if(packetCallback) {
+                        DPDK_INST_DELTA_TS_START;
 		        packetCallback(conf->rx_queue_list[i].userData,
 		                       rte_pktmbuf_mtod(pkts_burst[j], char *),
 			    	       pkts_burst[j]->data_len, rte_rdtsc());
+                        DPDK_INST_DELTA_TS_END;
+#ifdef DPDK_INST_ENABLE
+                        bucketCallbackDurationTotal += deltaT;
+                        bucketCallbackDurationSquareTotal += deltaT*deltaT;
+                        if(deltaT < bucketCallbackDurationMin) {
+                            bucketCallbackDurationMin = deltaT;
+                        }
+                        if(deltaT > bucketCallbackDurationMax) {
+                            bucketCallbackDurationMax = deltaT;
+                        }
+#endif
                     }
+                    DPDK_INST_DELTA_TS_START;
 		    rte_pktmbuf_free(pkts_burst[j]);
+                    DPDK_INST_DELTA_TS_END;
+#ifdef DPDK_INST_ENABLE
+                    bucketPacketFreeDurationTotal += deltaT;
+                    bucketPacketFreeDurationSquareTotal += deltaT*deltaT;
+                    if(deltaT < bucketPacketFreeDurationMin) {
+                        bucketPacketFreeDurationMin = deltaT;
+                    }
+                    if(deltaT > bucketPacketFreeDurationMax) {
+                        bucketPacketFreeDurationMax = deltaT;
+                    }
+#endif
+
 		    count++;
 		}
 
 		for (; j < num_rx; j++) {
                     if(packetCallback) {
+                        DPDK_INST_DELTA_TS_START;
 		        packetCallback(conf->rx_queue_list[i].userData,
 		                       rte_pktmbuf_mtod(pkts_burst[j], char *),
 			    	       pkts_burst[j]->data_len, rte_rdtsc());
+                        DPDK_INST_DELTA_TS_END;
+#ifdef DPDK_INST_ENABLE
+                        bucketCallbackDurationTotal += deltaT;
+                        bucketCallbackDurationSquareTotal += deltaT*deltaT;
+                        if(deltaT < bucketCallbackDurationMin) {
+                            bucketCallbackDurationMin = deltaT;
+                        }
+                        if(deltaT > bucketCallbackDurationMax) {
+                            bucketCallbackDurationMax = deltaT;
+                        }
+#endif
                     }
+                    DPDK_INST_DELTA_TS_START;
 		    rte_pktmbuf_free(pkts_burst[j]);
+                    DPDK_INST_DELTA_TS_END;
+#ifdef DPDK_INST_ENABLE
+                    bucketPacketFreeDurationTotal += deltaT;
+                    bucketPacketFreeDurationSquareTotal += deltaT*deltaT;
+                    if(deltaT < bucketPacketFreeDurationMin) {
+                        bucketPacketFreeDurationMin = deltaT;
+                    }
+                    if(deltaT > bucketPacketFreeDurationMax) {
+                        bucketPacketFreeDurationMax = deltaT;
+                    }
+#endif
 		    count++;
 		}
-	    }
+	    } else {
+#ifdef DPDK_INST_ENABLE
+                ++bucketNoneFoundCount;
+                bucketNoneFoundDurationTotal += deltaT;
+                bucketNoneFoundDurationSquareTotal += deltaT*deltaT;
+                if(deltaT < bucketNoneFoundDurationMin) {
+                    bucketNoneFoundDurationMin = deltaT;
+                }
+                if(deltaT > bucketNoneFoundDurationMax) {
+                    bucketNoneFoundDurationMax = deltaT;
+                }
+#endif
+            }
 	}
+
+#ifdef DPDK_INST_ENABLE
+        // Check to see if we should dump and reset the buckets
+        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts_loop);
+        uint64_t tempCurrentTime = ts_loop.tv_nsec + ts_loop.tv_sec * 1000000000UL;
+
+        if(tempCurrentTime - bucketStartTime >= DPDK_INST_BUCKET_SIZE) {
+            // Record how much extra time we're wasting here
+            DPDK_INST_DELTA_TS_START;
+
+            // Use this time to display only.
+            struct timespec ts_real;
+            clock_gettime(CLOCK_REALTIME, &ts_real);
+
+            // Display the data for this bucket/thread to stdout for now
+            printf("RXTX: receive_loop: METRICS %u %d %d %lu.%09lu %lu %lu : %lu %lu %lu %lu %lu : %lu %lu %lu %lu %lu : %lu %lu %lu %lu : %lu %lu %lu %lu : %lu %lu %lu %lu\n",
+                   lcore_id, port_id, queue_id, ts_real.tv_sec, ts_real.tv_nsec, bucketPriorWastedTime, (tempCurrentTime - bucketStartTime),
+                   bucketNoneFoundCount, bucketNoneFoundDurationTotal, bucketNoneFoundDurationSquareTotal, bucketNoneFoundDurationMin, bucketNoneFoundDurationMax,
+                   bucketBurstFoundCount, bucketBurstFoundDurationTotal, bucketBurstFoundDurationSquareTotal, bucketBurstFoundDurationMin, bucketBurstFoundDurationMax,
+                   bucketPacketCountTotal, bucketPacketCountSquareTotal, bucketPacketCountMin, bucketPacketCountMax,
+                   bucketCallbackDurationTotal, bucketCallbackDurationSquareTotal, bucketCallbackDurationMin, bucketCallbackDurationMax,
+                   bucketPacketFreeDurationTotal, bucketPacketFreeDurationSquareTotal, bucketPacketFreeDurationMin, bucketPacketFreeDurationMax);
+
+            // Reset the counters for next time around, other than the starttime and wasted time, which will be updated after this and kept.
+            // bucketStartTime = 0;
+            // bucketPriorWastedTime = 0;
+            bucketBurstFoundCount = 0;
+            bucketNoneFoundCount = 0;
+            bucketPacketCountTotal = 0;
+            bucketPacketCountSquareTotal = 0;
+            bucketPacketCountMin = UINT64_MAX;
+            bucketPacketCountMax = 0;
+            bucketBurstFoundDurationTotal = 0;
+            bucketBurstFoundDurationSquareTotal = 0;
+            bucketBurstFoundDurationMin = UINT64_MAX;
+            bucketBurstFoundDurationMax = 0;
+            bucketNoneFoundDurationTotal = 0;
+            bucketNoneFoundDurationSquareTotal = 0;
+            bucketNoneFoundDurationMin = UINT64_MAX;
+            bucketNoneFoundDurationMax = 0;
+            bucketCallbackDurationTotal = 0;
+            bucketCallbackDurationSquareTotal = 0;
+            bucketCallbackDurationMin = UINT64_MAX;
+            bucketCallbackDurationMax = 0;
+            bucketPacketFreeDurationTotal = 0;
+            bucketPacketFreeDurationSquareTotal = 0;
+            bucketPacketFreeDurationMin = UINT64_MAX;
+            bucketPacketFreeDurationMax = 0;
+
+            // Reset the start time for the next bucket
+            clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts_loop);
+            bucketStartTime = ts_loop.tv_nsec + ts_loop.tv_sec * 1000000000UL;
+
+            DPDK_INST_DELTA_TS_END;
+            bucketPriorWastedTime = deltaT;
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
In particular, added a lockless ring buffer between DPDK and Streams userspace, to prevent Streams queue jitter from causing DPDK to drop packets.  The PacketDPDKSource now requires C++11, since the ring buffer uses the C++11 atomics.

Also, add some rate limiting functions on all Packet*Source operators, to allow for particular types of packets to be rate limited right at the source, preventing copying a bunch of large (useless) packets into the rest of the Streams graph.

Other miscellaneous enhancements to the Packet*Sources, mostly for performance and unification of the operator APIs.

Also instrumented the DPDK code (disabled by default) to enable better understanding of where time is spent in DPDK processing.
