### PR TITLE
Fix the dnsAllFields() prototype in the DNS flattener code

### DIFF
--- a/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
+++ b/com.ibm.streamsx.network/com.ibm.streamsx.network.parse/DNSMessageParser/DNSMessageParser_h.cgt
@@ -189,8 +189,8 @@ private:
   SPL::blob DNS_EXTRA_DATA() { return parser.dnsExtra ? SPL::blob((const unsigned char*)parser.dnsExtra, (uint64_t)(parser.dnsEnd-parser.dnsExtra)) : SPL::blob(); }
 
   inline __attribute__((always_inline))
-  SPL::rstring DNS_ALL_FIELDS(SPL::rstring recordDelimiter, SPL::rstring fieldDelimiter, SPL::rstring subfieldDelimiter, SPL::list<SPL::uint16> rrTypes, SPL::uint64 captureSeconds, SPL::uint32 packetLen, SPL::uint32 srcAddr, SPL::uint32 dstAddr, SPL::uint16 srcUdpPort, SPL::uint16 dstUdpPort, SPL::uint8 protocol, SPL::uint32 payloadLength, SPL::uint16 mac16) 
-    { return flattener.dnsAllFields(captureSeconds, packetLen, htonl(srcAddr), htonl(dstAddr), srcUdpPort, dstUdpPort, protocol, payloadLength, mac16, parser, recordDelimiter.c_str(), fieldDelimiter.c_str(), subfieldDelimiter.c_str(), rrTypes); }
+  SPL::rstring DNS_ALL_FIELDS(SPL::rstring recordDelimiter, SPL::rstring fieldDelimiter, SPL::rstring subfieldDelimiter, SPL::list<SPL::uint16> rrTypes, SPL::uint64 captureSeconds, SPL::uint32 packetLen, SPL::uint32 srcAddr, SPL::uint32 dstAddr, SPL::uint16 srcUdpPort, SPL::uint16 dstUdpPort, SPL::uint8 protocol, SPL::uint32 payloadLength, SPL::uint16 tag)
+    { return flattener.dnsAllFields(captureSeconds, packetLen, htonl(srcAddr), htonl(dstAddr), srcUdpPort, dstUdpPort, protocol, payloadLength, tag, parser, recordDelimiter.c_str(), fieldDelimiter.c_str(), subfieldDelimiter.c_str(), rrTypes); }
 
   inline __attribute__((always_inline))
   SPL::int32 DNS_INCOMPATIBLE_FLAGS() { return parser.incompatibleFlags(); }

--- a/com.ibm.streamsx.network/impl/include/dns/DNSPacketFlattener.h
+++ b/com.ibm.streamsx.network/impl/include/dns/DNSPacketFlattener.h
@@ -370,10 +370,10 @@ DNSResponseNames dnsResponseNames;
  public:
 
   SPL::rstring dnsAllFields(double captureTime, uint32_t packetLength, NetworkHeaderParser& headers, DNSMessageParser& parser, const char* recordDelimiter, const char* fieldDelimiter, const char* subfieldDelimiter, SPL::list<SPL::uint16>& rrTypes) {
-    return dnsAllFields(captureTime, packetLength, headers.ipv4Header->saddr, headers.ipv4Header->daddr, headers.udpHeader->source, headers.udpHeader->dest, parser, recordDelimiter, fieldDelimiter, subfieldDelimiter, rrTypes);
+      return dnsAllFields(captureTime, packetLength, headers.ipv4Header->saddr, headers.ipv4Header->daddr, headers.udpHeader->source, headers.udpHeader->dest, headers.ipv4Header->protocol, headers.payloadLength, 0, parser, recordDelimiter, fieldDelimiter, subfieldDelimiter, rrTypes);
   }
 
-  SPL::rstring dnsAllFields(double captureTime, uint32_t packetLength, uint32_t srcAddr, uint32_t dstAddr, uint16_t udpSrcPort, uint16_t udpDstPort, DNSMessageParser& parser, const char* recordDelimiter, const char* fieldDelimiter, const char* subfieldDelimiter, SPL::list<SPL::uint16>& rrTypes) {
+  SPL::rstring dnsAllFields(double captureTime, uint32_t packetLength, uint32_t srcAddr, uint32_t dstAddr, uint16_t udpSrcPort, uint16_t udpDstPort, uint8_t protocol, uint32_t payloadLength, uint16_t tag, DNSMessageParser& parser, const char* recordDelimiter, const char* fieldDelimiter, const char* subfieldDelimiter, SPL::list<SPL::uint16>& rrTypes) {
     // allocate a buffer large enough to hold the largest possible string representation of a DNS message
     char buffer[1024*1024];
     size_t bufferLength = 0;


### PR DESCRIPTION
Allows some additional network header fields to get passed through.